### PR TITLE
更新了一些压缩包检测的手段、添加minecraft和GitHub为官方网站

### DIFF
--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -849,6 +849,14 @@ const DOMAIN_DATABASE = [
     keywords: ['AnyDesk', 'anydesk', '远程桌面'],
     isChineseBrand: false
   },
+  {
+    name: 'Github',
+    officialDomains: ['github.com'],
+    correctUrl: 'https://www.github.com',
+    category: SOFTWARE_CATEGORIES.DEVELOPER,
+    keywords: ['Github'],
+    isChineseBrand: false
+  },
 
   // ========== 游戏平台 ==========
   {
@@ -858,6 +866,14 @@ const DOMAIN_DATABASE = [
     category: SOFTWARE_CATEGORIES.GAME,
     keywords: ['WeGame', 'wegame'],
     isChineseBrand: true
+  },
+  {
+    name: 'Minecraft',
+    officialDomains: ['minecraft.net', 'minecraft.com'],
+    correctUrl: 'https://www.minecraft.net',
+    category: SOFTWARE_CATEGORIES.GAME,
+    keywords: ['Minecraft', 'minecraft', '我的世界'],
+    isChineseBrand: false
   },
   {
     name: '蒸汽平台',
@@ -1182,7 +1198,7 @@ export class DomainDatabase {
     for (const officialDomain of sortedOfficialDomains) {
       const dist = this._levenshtein(normalized, officialDomain);
       if (dist >= 1 && dist <= 2 && normalized.length >= officialDomain.length - 2
-          && normalized.length >= 6) {
+        && normalized.length >= 6) {
         const entry = domainToEntry.get(officialDomain);
         return {
           entry,

--- a/background/scoring-engine.js
+++ b/background/scoring-engine.js
@@ -343,12 +343,63 @@ export class ScoringEngine {
 
   // ==================== 工具方法 ====================
 
-  static isArchiveFile(filename) {
-    const lower = filename.toLowerCase();
-    return ARCHIVE_EXTENSIONS.some(ext => {
-      if (ext.startsWith('.')) return lower.endsWith(ext);
-      // 处理如 .tar.gz 的复合扩展名
-      return lower.endsWith(ext);
-    });
+  /**
+   * 检测文件是否为压缩包格式
+   * 三层检测：文件名扩展名 → 下载URL路径 → MIME类型
+   * @param {string} filename - 文件名（可能为空）
+   * @param {string} [url=''] - 下载URL（用于回退检测）
+   * @param {string} [mime=''] - MIME类型（用于回退检测）
+   * @returns {boolean}
+   */
+  static isArchiveFile(filename, url = '', mime = '') {
+    // 第一层：文件名扩展名检测（增加空值安全检查）
+    if (filename) {
+      const lower = filename.toLowerCase();
+      const matchByFilename = ARCHIVE_EXTENSIONS.some(ext => {
+        if (ext.startsWith('.')) return lower.endsWith(ext);
+        // 处理如 .tar.gz 的复合扩展名
+        return lower.endsWith(ext);
+      });
+      if (matchByFilename) return true;
+    }
+
+    // 第二层：下载URL路径检测（去除查询参数后检查扩展名）
+    if (url) {
+      try {
+        const urlObj = new URL(url);
+        const pathname = urlObj.pathname.toLowerCase();
+        const matchByUrl = ARCHIVE_EXTENSIONS.some(ext => {
+          if (ext.startsWith('.')) return pathname.endsWith(ext);
+          return pathname.endsWith(ext);
+        });
+        if (matchByUrl) return true;
+      } catch (e) { /* URL解析失败，跳过此层检测 */ }
+    }
+
+    // 第三层：MIME类型检测（17种常见压缩包MIME类型）
+    if (mime) {
+      const ARCHIVE_MIME_TYPES = [
+        'application/zip',
+        'application/x-rar-compressed',
+        'application/x-7z-compressed',
+        'application/x-tar',
+        'application/gzip',
+        'application/x-bzip2',
+        'application/x-xz',
+        'application/x-compress',
+        'application/x-iso9660-image',
+        'application/vnd.ms-cab-compressed',
+        'application/x-arj',
+        'application/x-lzh',
+        'application/zstd',
+        'application/x-compressed-tar',
+        'application/x-gzip',
+        'application/x-bzip',
+        'application/x-lzma'
+      ];
+      if (ARCHIVE_MIME_TYPES.includes(mime.toLowerCase())) return true;
+    }
+
+    return false;
   }
 }

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -541,14 +541,38 @@ chrome.webNavigation.onCompleted.addListener(async (details) => {
 // 下载创建事件
 chrome.downloads.onCreated.addListener(async (downloadItem) => {
   try {
-    if (!ScoringEngine.isArchiveFile(downloadItem.filename)) return;
+    // 三层检测：文件名 + URL路径 + MIME类型
+    if (!ScoringEngine.isArchiveFile(downloadItem.filename, downloadItem.url, downloadItem.mime)) return;
 
     console.log('[ServiceWorker] 检测到压缩包下载:', downloadItem.filename);
 
-    // 尝试找到源标签页
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (tabs.length === 0) return;
-    const tabId = tabs[0].id;
+    // 尝试找到源标签页：优先通过 referrer 匹配所有已打开的标签页
+    let tabId = null;
+    if (downloadItem.referrer) {
+      try {
+        const referrerUrl = new URL(downloadItem.referrer);
+        const allTabs = await chrome.tabs.query({});
+        const sourceTab = allTabs.find(tab => {
+          try {
+            return new URL(tab.url || '').hostname === referrerUrl.hostname;
+          } catch (e) { return false; }
+        });
+        if (sourceTab) {
+          tabId = sourceTab.id;
+          console.log('[ServiceWorker] 通过referrer定位到源标签页:', sourceTab.url);
+        }
+      } catch (e) { /* referrer解析失败，回退到活跃标签页 */ }
+    }
+
+    // 回退：通过referrer未找到时，查询活跃标签页
+    if (!tabId) {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tabs.length === 0) {
+        console.log('[ServiceWorker] 无法找到下载源标签页，跳过下载检测');
+        return;
+      }
+      tabId = tabs[0].id;
+    }
 
     const tabState = await loadTabState(tabId);
 
@@ -565,9 +589,19 @@ chrome.downloads.onCreated.addListener(async (downloadItem) => {
       downloadId: downloadItem.id
     };
 
-    // 重新计算规则二
-    const existingScore = Object.values(tabState.ruleResults)
+    // 重新计算规则二（先使用现有tabState评分）
+    let existingScore = Object.values(tabState.ruleResults)
       .reduce((sum, r) => sum + (r.score || 0), 0);
+
+    // 竞态条件回退：如果 tabState 尚未分析完成（所有规则评分为0），从缓存补充
+    if (!tabState.isAnalyzed || existingScore === 0) {
+      const cached = await CacheManager.get(tabState.domain);
+      if (cached && cached.ruleResults) {
+        existingScore = Object.values(cached.ruleResults)
+          .reduce((sum, r) => sum + (r.score || 0), 0);
+        console.log('[ServiceWorker] 缓存回退：从CacheManager补充评分:', tabState.domain, existingScore);
+      }
+    }
     const rule2Result = ScoringEngine._evaluateRule2(tabState.downloadState, existingScore);
 
     tabState.ruleResults.rule2 = rule2Result;


### PR DESCRIPTION
scoring-engine.js:354-404 ，原先函数仅检查 filename，若 Chrome 在 onCreated 事件触发时 downloadItem.filename 为空，检测将直接失败。
新函数签名：isArchiveFile(filename, url = '', mime = '')，增加三层检测：
（if (filename)）；
下载 URL 路径	解析 URL，去除查询参数后检查 pathname 扩展名
MIME 类型，17 种压缩包 MIME，包括 application/zip、application/x-rar-compressed、application/x-7z-compressed 等 调用方已同步更新为：ScoringEngine.isArchiveFile(downloadItem.filename, downloadItem.url, downloadItem.mime)

service-worker.js:549-575 ， 原先使用 chrome.tabs.query({ active: true, currentWindow: true })，仅查找活跃标签页，下载由后台标签页或弹窗触发时完全无法定位。
现在优先通过 downloadItem.referrer 解析域名，与所有已打开标签页逐一匹配 hostname，定位真正的下载发起标签页 回退到活跃标签页查询，完全找不到时记录日志并退出

service-worker.js:596-603 ， 原先当下载在 analyzePage 完成前触发时，tabState.ruleResults 所有规则评分均为 0，导致即使从钓鱼网站下载，规则二也只能 +10 分。
若 tabState.isAnalyzed === false 或 existingScore === 0，则从 CacheManager.get(domain) 查找该域名的缓存分析结果，提取已有的 ruleResults 评分来补充 existingScore。