### PR TITLE
修复: file:// 等非 http(s) 协议 URL 100% 触发误报 (Fixes #6)

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -29,6 +29,30 @@ import {
   STORAGE_KEYS, CACHE_TTL
 } from '../utils/constants.js';
 
+// ==================== URL 协议守卫 ====================
+
+/**
+ * 判断 URL 是否应跳过分析（仅分析 http/https 协议）
+ *
+ * 修复历史误报：file://、data:、ftp:、view-source: 等协议的 URL
+ *  - 没有可分析的主机名（hostname 为 ""）
+ *  - 历史上所有 file:// 页面共享同一个空字符串缓存键 `domain_cache_`，
+ *    一次恶意缓存会污染所有本地文件
+ *  - Content Script 在 `<all_urls>` 下也会运行于 file:// 页面并发送数据
+ *
+ * @param {string} url
+ * @returns {boolean} true 表示应跳过（不分析）
+ */
+function shouldSkipUrl(url) {
+  if (!url || typeof url !== 'string') return true;
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol !== 'http:' && protocol !== 'https:';
+  } catch (e) {
+    return true; // 无法解析的 URL 视为应跳过
+  }
+}
+
 // ==================== 缓存清洗 ====================
 
 /**
@@ -489,6 +513,16 @@ function openWarningWindow(tabState) {
  * 完整的页面分析流程
  */
 async function analyzePage(tabId, url, domain, pageMetrics, linkMetrics) {
+  // 防御性深度：所有进入分析入口的 URL 都先经协议守卫
+  // 覆盖三个调用方：webNavigation、PAGE_ANALYSIS_RESULT 消息、REMOVE_FROM_WHITELIST
+  if (shouldSkipUrl(url)) {
+    console.log('[ServiceWorker] 跳过非 http(s) URL:', url);
+    await CacheManager.remove('').catch(() => {});
+    resetIcon(tabId);
+    await clearTabState(tabId);
+    return;
+  }
+
   let tabState = await loadTabState(tabId);
 
   // 白名单检查：如果在白名单中，跳过所有检测
@@ -595,9 +629,13 @@ chrome.webNavigation.onCompleted.addListener(async (details) => {
   if (details.frameId !== 0) return;
   const { tabId, url } = details;
 
-  if (url.startsWith('chrome://') || url.startsWith('chrome-extension://') ||
-      url.startsWith('about:') || url.startsWith('edge://')) {
-    resetIcon(tabId); await clearTabState(tabId); return;
+  // 内部浏览器页面 / 本地文件 / 非 http(s) 协议：直接跳过
+  // （一次性清理空域名旧缓存，避免历史恶意缓存影响所有 file:// 页面）
+  if (shouldSkipUrl(url)) {
+    await CacheManager.remove('').catch(() => {});
+    resetIcon(tabId);
+    await clearTabState(tabId);
+    return;
   }
 
   const domain = UrlUtils.extractHostname(url);


### PR DESCRIPTION
## 修复 issue #6：访问本地URL 100%触发误报

### 问题描述
打开 `file://` 等本地 HTML 文件时，插件 100% 弹出红色徽章与警告弹窗，所有本地文件都被误判为恶意网站。

### 根因

1. `webNavigation.onCompleted` 的协议白名单只包含 `chrome://` 等浏览器内部协议，遗漏了 `file://`、`data:`、`ftp:`、`view-source:` 等
2. 所有 `file://` 页面共享同一个空字符串缓存键 `domain_cache_`，一次恶意缓存污染所有本地文件
3. Content Script 在 `<all_urls>` 下也会运行于 `file://` 页面，并通过 `PAGE_ANALYSIS_RESULT` 消息触发 `analyzePage`，绕过 webNavigation 的协议检查
4. `analyzePage` 入口无协议守卫，三个调用方（webNavigation、消息处理器、移除白名单）都可能被注入非 http(s) URL

### 修复方案

- 新增 `shouldSkipUrl()` 工具函数，仅放行 `http:` 与 `https:` 协议
- `webNavigation.onCompleted` 改用 `shouldSkipUrl` 替换原硬编码 `startsWith` 列表
- `analyzePage` 入口增加协议守卫（防御性深度），覆盖所有调用路径
- 一次性清理空域名旧缓存（`domain_cache_`），避免历史脏数据影响

### 变更范围
- 1 文件，+41 / -3 行
- 仅修改 `background/service-worker.js`

### 验证

代码追踪 4 类 URL：

| URL 类型 | 行为 |
|---------|------|
| `http://` / `https://` | 正常分析 |
| `file://` / `data:` / `ftp:` / `view-source:` / `javascript:` | 跳过分析 + 清空域名缓存 |
| `chrome://` / `chrome-extension://` / `about:` / `edge://` | 跳过分析 + 清空域名缓存 |
| 畸形 URL / 空 URL | 跳过分析 + 清空域名缓存 |

Fixes #6