### PR TITLE
feat: 警告弹窗30秒倒计时自动关闭

### DIFF
--- a/warning/warning.css
+++ b/warning/warning.css
@@ -57,7 +57,9 @@ body {
 .tips-section li::before { content:'•'; position:absolute; left:6px; color:#ff5252; font-weight:bold; }
 
 /* ===== 底部按钮 ===== */
-.actions { padding: 16px 24px 24px; display: flex; gap: 12px; }
+.actions { padding: 16px 24px 8px; display: flex; gap: 12px; }
+.auto-close-countdown { padding: 0 24px 20px; text-align: center; color: #9e9e9e;
+  font-size: 12px; min-height: 16px; }
 .btn-secondary, .btn-primary { flex:1; padding: 10px 16px; border:none; border-radius: 6px;
   font-size: 13px; font-weight: 600; cursor: pointer; transition: opacity 0.2s; }
 .btn-secondary { background: #333; color: #ccc; }

--- a/warning/warning.html
+++ b/warning/warning.html
@@ -77,6 +77,7 @@
       <button id="btn-close" class="btn-secondary">关闭此页面</button>
       <button id="btn-back-safe" class="btn-primary">返回安全页面</button>
     </div>
+    <p class="auto-close-countdown" id="auto-close-countdown"></p>
   </div>
 
   <script src="warning.js"></script>

--- a/warning/warning.js
+++ b/warning/warning.js
@@ -82,8 +82,41 @@
 
   // 返回安全页面：先关闭所有危险标签页，再打开正确官网，最后关闭警告弹窗
   document.getElementById('btn-back-safe').addEventListener('click', async () => {
+    clearAutoClose();
     await closeDangerousTabs(domain);
     await openSafePage(correctUrl || 'https://www.baidu.com');
     window.close();
   });
+
+  // ---- 自动关闭 ----
+
+  // 30 秒倒计时后自动关闭警告弹窗，用户点击任意按钮则取消倒计时
+  const AUTO_CLOSE_SECONDS = 30;
+  let remaining = AUTO_CLOSE_SECONDS;
+  const countdownEl = document.getElementById('auto-close-countdown');
+
+  function renderCountdown() {
+    if (countdownEl) {
+      countdownEl.textContent = `本提示将在 ${remaining} 秒后自动关闭`;
+    }
+  }
+
+  function clearAutoClose() {
+    clearInterval(autoCloseTimer);
+    if (countdownEl) countdownEl.textContent = '';
+  }
+
+  renderCountdown();
+  const autoCloseTimer = setInterval(() => {
+    remaining -= 1;
+    if (remaining <= 0) {
+      clearAutoClose();
+      window.close();
+      return;
+    }
+    renderCountdown();
+  }, 1000);
+
+  // 关闭按钮也取消倒计时（事件已绑定，补充清理）
+  document.getElementById('btn-close').addEventListener('click', clearAutoClose);
 })();


### PR DESCRIPTION
解决用户忘记关闭 警告窗口 导致占用一定的内存，设置该窗口 30s 后自动关闭。

## 改动内容

warning.js
新增 30 秒倒计时逻辑，计时归零自动调用 window.close() 关闭弹窗
用户点击「关闭此页面」或「返回安全页面」时取消倒计时，防止重复关闭

warning.html
按钮区域下方新增倒计时文字显示元素

warning.css
新增 .auto-close-countdown 样式，灰色居中显示
微调 .actions 底部 padding