### PR TITLE
修复 Kimi 的url

### DIFF
--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -534,7 +534,7 @@ const DOMAIN_DATABASE = [
   },
   {
     name: 'Kimi',
-    officialDomains: ['kimi.moonshot.cn'],
+    officialDomains: ['kimi.moonshot.cn','kimi.com'],
     correctUrl: 'https://www.kimi.com',
     category: SOFTWARE_CATEGORIES.AI_CHAT,
     keywords: ['Kimi', 'kimi', 'moonshot'],

--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -535,7 +535,7 @@ const DOMAIN_DATABASE = [
   {
     name: 'Kimi',
     officialDomains: ['kimi.moonshot.cn'],
-    correctUrl: 'https://kimi.moonshot.cn',
+    correctUrl: 'https://www.kimi.com',
     category: SOFTWARE_CATEGORIES.AI_CHAT,
     keywords: ['Kimi', 'kimi', 'moonshot'],
     isChineseBrand: true


### PR DESCRIPTION
访问[cn](https://kimi.moonshot.cn)域名会重定向到[com](https://www.kimi.com/)域名

---

<img width="1066" height="713" alt="kimi url" src="https://github.com/user-attachments/assets/8f97265d-0f28-4c5a-a7c9-5983fd665335" />
