### PR TITLE
feat: 域名补全

### DIFF
--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -47,7 +47,8 @@ export const SOFTWARE_CATEGORIES = {
   GAME: '游戏平台',
   GAME_ACCELERATOR: '游戏加速器',
   NEWS_INFO: '新闻/信息',
-  GOV_SERVICE: '政务服务'
+  GOV_SERVICE: '政务服务',
+  EDUCATION: '高校/教育'
 };
 
 const DOMAIN_DATABASE = [
@@ -1039,6 +1040,433 @@ const DOMAIN_DATABASE = [
     category: SOFTWARE_CATEGORIES.NEWS_INFO,
     keywords: ['知乎', 'zhihu'],
     isChineseBrand: true
+  },
+  // ========== 高校/教育 ==========
+  {
+    name: '清华大学',
+    officialDomains: ['tsinghua.edu.cn'],
+    correctUrl: 'https://www.tsinghua.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['清华', 'tsinghua'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京大学',
+    officialDomains: ['pku.edu.cn'],
+    correctUrl: 'https://www.pku.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北大', 'pku'],
+    isChineseBrand: true
+  },
+  {
+    name: '浙江大学',
+    officialDomains: ['zju.edu.cn'],
+    correctUrl: 'https://www.zju.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['浙大', 'zju'],
+    isChineseBrand: true
+  },
+  {
+    name: '上海交通大学',
+    officialDomains: ['sjtu.edu.cn'],
+    correctUrl: 'https://www.sjtu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['上海交大', 'sjtu'],
+    isChineseBrand: true
+  },
+  {
+    name: '复旦大学',
+    officialDomains: ['fudan.edu.cn'],
+    correctUrl: 'https://www.fudan.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['复旦', 'fudan'],
+    isChineseBrand: true
+  },
+  {
+    name: '南京大学',
+    officialDomains: ['nju.edu.cn'],
+    correctUrl: 'https://www.nju.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['南大', 'nju'],
+    isChineseBrand: true
+  },
+  {
+    name: '中国科学技术大学',
+    officialDomains: ['ustc.edu.cn'],
+    correctUrl: 'https://www.ustc.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['中科大', 'ustc'],
+    isChineseBrand: true
+  },
+  {
+    name: '华中科技大学',
+    officialDomains: ['hust.edu.cn'],
+    correctUrl: 'https://www.hust.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['华科', 'hust'],
+    isChineseBrand: true
+  },
+  {
+    name: '武汉大学',
+    officialDomains: ['whu.edu.cn'],
+    correctUrl: 'https://www.whu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['武大', 'whu'],
+    isChineseBrand: true
+  },
+  {
+    name: '西安交通大学',
+    officialDomains: ['xjtu.edu.cn'],
+    correctUrl: 'https://www.xjtu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['西安交大', 'xjtu'],
+    isChineseBrand: true
+  },
+  {
+    name: '中山大学',
+    officialDomains: ['sysu.edu.cn'],
+    correctUrl: 'https://www.sysu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['中大', 'sysu'],
+    isChineseBrand: true
+  },
+  {
+    name: '哈尔滨工业大学',
+    officialDomains: ['hit.edu.cn'],
+    correctUrl: 'https://www.hit.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['哈工大', 'hit'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京航空航天大学',
+    officialDomains: ['buaa.edu.cn'],
+    correctUrl: 'https://www.buaa.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北航', 'buaa'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京理工大学',
+    officialDomains: ['bit.edu.cn'],
+    correctUrl: 'https://www.bit.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北理工', 'bit'],
+    isChineseBrand: true
+  },
+  {
+    name: '四川大学',
+    officialDomains: ['scu.edu.cn'],
+    correctUrl: 'https://www.scu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['川大', 'scu'],
+    isChineseBrand: true
+  },
+  {
+    name: '南开大学',
+    officialDomains: ['nankai.edu.cn'],
+    correctUrl: 'https://www.nankai.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['南开', 'nankai'],
+    isChineseBrand: true
+  },
+  {
+    name: '同济大学',
+    officialDomains: ['tongji.edu.cn'],
+    correctUrl: 'https://www.tongji.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['同济', 'tongji'],
+    isChineseBrand: true
+  },
+  {
+    name: '天津大学',
+    officialDomains: ['tju.edu.cn'],
+    correctUrl: 'https://www.tju.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['天大', 'tju'],
+    isChineseBrand: true
+  },
+  {
+    name: '东南大学',
+    officialDomains: ['seu.edu.cn'],
+    correctUrl: 'https://www.seu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['东南', 'seu'],
+    isChineseBrand: true
+  },
+  {
+    name: '中国人民大学',
+    officialDomains: ['ruc.edu.cn'],
+    correctUrl: 'https://www.ruc.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['人大', 'ruc'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京师范大学',
+    officialDomains: ['bnu.edu.cn'],
+    correctUrl: 'https://www.bnu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北师大', 'bnu'],
+    isChineseBrand: true
+  },
+  {
+    name: '华东师范大学',
+    officialDomains: ['ecnu.edu.cn'],
+    correctUrl: 'https://www.ecnu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['华师大', 'ecnu'],
+    isChineseBrand: true
+  },
+  {
+    name: '厦门大学',
+    officialDomains: ['xmu.edu.cn'],
+    correctUrl: 'https://www.xmu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['厦大', 'xmu'],
+    isChineseBrand: true
+  },
+  {
+    name: '吉林大学',
+    officialDomains: ['jlu.edu.cn'],
+    correctUrl: 'https://www.jlu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['吉大', 'jlu'],
+    isChineseBrand: true
+  },
+  {
+    name: '山东大学',
+    officialDomains: ['sdu.edu.cn'],
+    correctUrl: 'https://www.sdu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['山大', 'sdu'],
+    isChineseBrand: true
+  },
+  {
+    name: '大连理工大学',
+    officialDomains: ['dlut.edu.cn'],
+    correctUrl: 'https://www.dlut.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['大工', 'dlut'],
+    isChineseBrand: true
+  },
+  {
+    name: '华南理工大学',
+    officialDomains: ['scut.edu.cn'],
+    correctUrl: 'https://www.scut.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['华南理工', 'scut'],
+    isChineseBrand: true
+  },
+  {
+    name: '西北工业大学',
+    officialDomains: ['nwpu.edu.cn'],
+    correctUrl: 'https://www.nwpu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['西工大', 'nwpu'],
+    isChineseBrand: true
+  },
+  {
+    name: '电子科技大学',
+    officialDomains: ['uestc.edu.cn'],
+    correctUrl: 'https://www.uestc.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['成电', 'uestc'],
+    isChineseBrand: true
+  },
+  {
+    name: '中国农业大学',
+    officialDomains: ['cau.edu.cn'],
+    correctUrl: 'https://www.cau.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['中国农大', 'cau'],
+    isChineseBrand: true
+  },
+  {
+    name: '兰州大学',
+    officialDomains: ['lzu.edu.cn'],
+    correctUrl: 'https://www.lzu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['兰大', 'lzu'],
+    isChineseBrand: true
+  },
+  {
+    name: '重庆大学',
+    officialDomains: ['cqu.edu.cn'],
+    correctUrl: 'https://www.cqu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['重大', 'cqu'],
+    isChineseBrand: true
+  },
+  {
+    name: '中南大学',
+    officialDomains: ['csu.edu.cn'],
+    correctUrl: 'https://www.csu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['中南', 'csu'],
+    isChineseBrand: true
+  },
+  {
+    name: '湖南大学',
+    officialDomains: ['hnu.edu.cn'],
+    correctUrl: 'https://www.hnu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['湖大', 'hnu'],
+    isChineseBrand: true
+  },
+  {
+    name: '东北大学',
+    officialDomains: ['neu.edu.cn'],
+    correctUrl: 'https://www.neu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['东北', 'neu'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京科技大学',
+    officialDomains: ['ustb.edu.cn'],
+    correctUrl: 'https://www.ustb.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北科大', 'ustb'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京交通大学',
+    officialDomains: ['bjtu.edu.cn'],
+    correctUrl: 'https://www.bjtu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北交大', 'bjtu'],
+    isChineseBrand: true
+  },
+  {
+    name: '北京邮电大学',
+    officialDomains: ['bupt.edu.cn'],
+    correctUrl: 'https://www.bupt.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['北邮', 'bupt'],
+    isChineseBrand: true
+  },
+  {
+    name: '国防科技大学',
+    officialDomains: ['nudt.edu.cn'],
+    correctUrl: 'https://www.nudt.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['国防科大', 'nudt'],
+    isChineseBrand: true
+  },
+  {
+    name: '南京航空航天大学',
+    officialDomains: ['nuaa.edu.cn'],
+    correctUrl: 'https://www.nuaa.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['南航', 'nuaa'],
+    isChineseBrand: true
+  },
+  {
+    name: '南京理工大学',
+    officialDomains: ['njust.edu.cn'],
+    correctUrl: 'https://www.njust.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['南理工', 'njust'],
+    isChineseBrand: true
+  },
+  {
+    name: '西安电子科技大学',
+    officialDomains: ['xidian.edu.cn'],
+    correctUrl: 'https://www.xidian.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['西电', 'xidian'],
+    isChineseBrand: true
+  },
+  {
+    name: '武汉理工大学',
+    officialDomains: ['whut.edu.cn'],
+    correctUrl: 'https://www.whut.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['武理工', 'whut'],
+    isChineseBrand: true
+  },
+  {
+    name: '中国地质大学（武汉）',
+    officialDomains: ['cug.edu.cn'],
+    correctUrl: 'https://www.cug.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['地大', 'cug'],
+    isChineseBrand: true
+  },
+  {
+    name: '华中师范大学',
+    officialDomains: ['ccnu.edu.cn'],
+    correctUrl: 'https://www.ccnu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['华师', 'ccnu'],
+    isChineseBrand: true
+  },
+  {
+    name: '上海科技大学',
+    officialDomains: ['shanghaitech.edu.cn'],
+    correctUrl: 'https://www.shanghaitech.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['上科大', 'shanghaitech'],
+    isChineseBrand: true
+  },
+  {
+    name: '南方科技大学',
+    officialDomains: ['sustech.edu.cn'],
+    correctUrl: 'https://www.sustech.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['南科大', 'sustech'],
+    isChineseBrand: true
+  },
+  {
+    name: '上海大学',
+    officialDomains: ['shu.edu.cn'],
+    correctUrl: 'https://www.shu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['上大', 'shu'],
+    isChineseBrand: true
+  },
+  {
+    name: '郑州大学',
+    officialDomains: ['zzu.edu.cn'],
+    correctUrl: 'https://www.zzu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['郑大', 'zzu'],
+    isChineseBrand: true
+  },
+  {
+    name: '云南大学',
+    officialDomains: ['ynu.edu.cn'],
+    correctUrl: 'https://www.ynu.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['云大', 'ynu'],
+    isChineseBrand: true
+  },
+  {
+    name: '西湖大学',
+    officialDomains: ['westlake.edu.cn'],
+    correctUrl: 'https://www.westlake.edu.cn',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['西湖', 'westlake'],
+    isChineseBrand: true
+  },
+  {
+    name: '麻省理工学院',
+    officialDomains: ['mit.edu'],
+    correctUrl: 'https://www.mit.edu',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['MIT', '麻省'],
+    isChineseBrand: false,
+    isNonChineseBrand: true
+  },
+  {
+    name: '斯坦福大学',
+    officialDomains: ['stanford.edu'],
+    correctUrl: 'https://www.stanford.edu',
+    category: SOFTWARE_CATEGORIES.EDUCATION,
+    keywords: ['Stanford', '斯坦福'],
+    isChineseBrand: false,
+    isNonChineseBrand: true
   }
 ];
 

--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -502,7 +502,7 @@ const DOMAIN_DATABASE = [
   },
   {
     name: '通义千问',
-    officialDomains: ['tongyi.aliyun.com', 'qianwen.aliyun.com'],
+    officialDomains: ['tongyi.aliyun.com', 'qianwen.aliyun.com', 'qianwen.com'],
     correctUrl: 'https://tongyi.aliyun.com',
     category: SOFTWARE_CATEGORIES.AI_CHAT,
     keywords: ['通义千问', 'tongyi', 'qianwen'],

--- a/background/icp-utils.js
+++ b/background/icp-utils.js
@@ -186,6 +186,23 @@ const ICP_EXEMPT_DOMAINS = new Set([
   'gov.uk',       // 英国政府
   'gov.au',       // 澳大利亚政府
   'gov.sg',       // 新加坡政府
+
+  // —— 保留/专用域名（不暴露公网，无需 ICP 备案）——
+  // 本地/内网专用（RFC 6761/6762/8375，不暴露公网）
+  'local',         // RFC 6762: 局域网 mDNS（打印机/NAS/树莓派）
+  'localhost',     // RFC 6761: 本机回环（127.0.0.1）
+  'home.arpa',     // RFC 8375: 家庭内网
+  'internal',      // ICANN 保留: 企业内部网络
+  'test',          // RFC 6761: 开发测试
+  // 文档/示例专用（RFC 2606/6761，禁止实际使用）
+  'example',       // RFC 6761: 文档示例（www.example.com）
+  'example.com',   // RFC 2606: 通用示例域名
+  'example.net',   // RFC 2606: 通用示例域名
+  'example.org',   // RFC 2606: 通用示例域名
+  // 反向解析与基础架构
+  'arpa',          // 根域: DNS 基础设施
+  'in-addr.arpa',  // RFC 1035: IPv4 反向解析
+  'ip6.arpa',      // RFC 3596: IPv6 反向解析
 ]);
 
 /**

--- a/background/icp-utils.js
+++ b/background/icp-utils.js
@@ -54,11 +54,16 @@ const ICP_EXEMPT_DOMAINS = new Set([
   'heroku.com', 'herokuapp.com',
   'cloudflare.com', 'cloudflarepages.dev',
   'firebase.google.com', 'firebaseapp.com',
+  'jetbrains.com',
+
+  // —— 科研 ——
+  'mathworks.com',
 
   // —— 百科 / 知识 ——
   'wikipedia.org', 'wikimedia.org', 'wikiwand.com',
   'mozilla.org', 'developer.mozilla.org',
   'w3.org', 'w3schools.com',
+  'vndb.org',
 
   // —— 非中国软件 / 工具 ——
   'firefox.com',
@@ -101,6 +106,7 @@ const ICP_EXEMPT_DOMAINS = new Set([
   'nintendo.com',
   'playstation.com',
   'xbox.com',
+  'dlsite.com',
 
   // —— 云服务 / SaaS ——
   'dropbox.com', 'dropboxusercontent.com',
@@ -120,6 +126,8 @@ const ICP_EXEMPT_DOMAINS = new Set([
   'sendgrid.net',
   'twilio.com',
   'stripe.com',
+  'vultr.com',
+  'cloudcone.com',
 
   // —— AI / 研究 ——
   'openai.com', 'chatgpt.com',

--- a/background/icp-utils.js
+++ b/background/icp-utils.js
@@ -165,6 +165,27 @@ const ICP_EXEMPT_DOMAINS = new Set([
   'proton.me', 'protonmail.com',
   'mega.nz', 'mega.io',
   'mediafire.com',
+
+  // —— 教育机构（全局匹配 .edu / .edu.cn / .edu.jp 等）——
+  'edu',
+  'edu.cn',
+  'edu.jp',
+  'ac.jp',        // 日本学术机构（如 u-tokyo.ac.jp）
+  'ac.cn',        // 中国科研机构（如 cas.ac.cn）
+  'ac.kr',        // 韩国学术机构
+  'ac.uk',        // 英国学术机构
+  'ac.th',        // 泰国学术机构
+
+  // —— 政府机构（全局匹配 .gov / .gov.cn 等）——
+  'gov',
+  'gov.cn',
+  'gov.hk',
+  'gov.tw',
+  'go.jp',        // 日本政府
+  'go.kr',        // 韩国政府
+  'gov.uk',       // 英国政府
+  'gov.au',       // 澳大利亚政府
+  'gov.sg',       // 新加坡政府
 ]);
 
 /**


### PR DESCRIPTION
解决 Closes #19 

## 变更内容

### 1. 域名数据库 — 通义千问（domain-database.js）
- 新增官方别名域名 `qianwen.com`，补全通义千问域名覆盖

### 2. ICP 免备案域名补全（icp-utils.js）
新增 6 个 ICP 免备案域名，按分类整理：

| 域名 | 分类 | 说明 |
|---|---|---|
| `jetbrains.com` | 开发工具 | JetBrains 系列 IDE |
| `mathworks.com` | 科研 | MATLAB |
| `vndb.org` | 百科/知识 | Visual Novel Database |
| `dlsite.com` | 非中国软件 | DLsite 同人平台 |
| `vultr.com` | 云服务 | Vultr 云主机 |
| `cloudcone.com` | 云服务 | CloudCone 云主机 |

### 3. 教育/政府机构 ICP 豁免（icp-utils.js）
利用 `isIcpExempt()` 的后缀匹配机制，一条规则覆盖整个 TLD / 子域：

| 域名 | 覆盖范围 |
|---|---|
| `edu` | 全球教育机构（`stanford.edu`、`mit.edu`） |
| `edu.cn` | 中国教育机构（`pku.edu.cn`、`tsinghua.edu.cn`） |
| `edu.jp` | 日本教育机构 |
| `ac.jp` / `ac.cn` / `ac.kr` / `ac.uk` / `ac.th` | 各国学术机构 |
| `gov` | 全球政府网站（`whitehouse.gov`、`nasa.gov`） |
| `gov.cn` / `gov.hk` / `gov.tw` | 大中华区政府站点 |
| `go.jp` / `go.kr` / `gov.uk` / `gov.au` / `gov.sg` | 各国政府机构 |

### 4. 高校域名防伪检测（domain-database.js）
新增 `EDUCATION: '高校/教育'` 分类，收录 **53 所高校** 域名：

**C9 联盟：** 清华、北大、浙大、上交、复旦、南大、中科大、哈工大、西交

**985 重点院校：** 武大、华科、中山、川大、南开、同济、天大、东南、人大、北师大、华师大、厦大、吉大、山大、大工、华南理工、西工大、成电、农大、兰大、重大、中南、湖大、东北大学、国防科大

**特色强校：** 北邮、西电、南航、南理工、武理工、地大、华师、上科大、南科大、西湖大学

**国际名校：** MIT（麻省理工）、Stanford（斯坦福）

> 子域名自动匹配 — 镜像站（如 `mirrors.tuna.tsinghua.edu.cn`）自动识别为官方域名，不会被标记仿冒。

### 5. 保留/专用域名 ICP 豁免（icp-utils.js）
覆盖三类不暴露公网的域名，按 RFC 标准分类：

| 域名 | 标准 | 说明 |
|---|---|---|
| `local` | RFC 6762 | 局域网 mDNS |
| `localhost` | RFC 6761 | 本机回环 |
| `home.arpa` | RFC 8375 | 家庭内网 |
| `internal` | ICANN 保留 | 企业内部网络 |
| `test` | RFC 6761 | 开发测试环境 |
| `example` / `.com` / `.net` / `.org` | RFC 2606/6761 | 文档/教程示例域名 |
| `arpa` / `in-addr.arpa` / `ip6.arpa` | RFC 1035/3596 | DNS 反向解析基础设施 |