### PR TITLE
feat: ICP备案查询系统优化——黑名单过滤+可点击链接核验评分

### DIFF
--- a/background/icp-utils.js
+++ b/background/icp-utils.js
@@ -226,6 +226,26 @@ const PROVINCE_ABBREVIATIONS = [
 // 省份简称正则片段
 const PROVINCE_PATTERN = PROVINCE_ABBREVIATIONS.join('|');
 
+// ==================== ICP 备案号黑名单 ====================
+// 以下为已知的占位/虚假备案号，匹配到则视为未找到备案
+// 常用于模板演示或伪装成已备案的虚假号码
+// 涵盖所有省级行政区（31个）的 ICP备/证 格式
+const ICP_BLACKLIST = new Set(
+  (() => {
+    const PROVINCES = [...'京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤川青藏琼宁'];
+    const entries = [];
+    for (const p of PROVINCES) {
+      for (const t of ['备', '证']) {
+        entries.push(`${p}ICP${t}10000000号`);
+        entries.push(`${p}ICP${t}10000000号-1`);
+      }
+    }
+    return entries;
+  })()
+);
+// 额外：全零数字（如 00000000 开头）在所有格式下均视为无效
+// 该检测在 isBlacklistedIcp() 方法中通过正则完成
+
 /**
  * ICP备案号工具类
  */
@@ -461,6 +481,23 @@ export class IcpUtils {
       if (ICP_EXEMPT_DOMAINS.has(parent)) return true;
     }
 
+    return false;
+  }
+
+  /**
+   * 检查 ICP 备案号是否在黑名单中（已知占位/虚假号码）
+   * @param {string} icpNumber - ICP 备案号
+   * @returns {boolean}
+   */
+  static isBlacklistedIcp(icpNumber) {
+    if (!icpNumber) return false;
+    const trimmed = icpNumber.trim();
+    if (ICP_BLACKLIST.has(trimmed)) return true;
+    // 额外检查：数字部分全部为零的号码也视为无效
+    if (/\d+/.test(trimmed)) {
+      const digits = trimmed.match(/\d+/g);
+      if (digits && digits.some(d => /^0{6,}$/.test(d))) return true;
+    }
     return false;
   }
 }

--- a/background/scoring-engine.js
+++ b/background/scoring-engine.js
@@ -33,7 +33,7 @@ import { UrlUtils } from '../utils/url-utils.js';
 import { TrustedPlatforms } from '../utils/trusted-platforms.js';
 import {
   SCORE_THRESHOLD, SCORE_RULE_1, SCORE_RULE_2_HIGH, SCORE_RULE_2_LOW,
-  SCORE_RULE_3, SCORE_RULE_5, SCORE_RULE_5_PARTIAL, RISK_LEVEL,
+  SCORE_RULE_3, SCORE_RULE_3_FAKE, SCORE_RULE_5, SCORE_RULE_5_PARTIAL, RISK_LEVEL,
   SCORE_RULE_4A_SAME_PAGE, SCORE_RULE_4A_DEAD_LINK,
   SCORE_RULE_4A_DUPLICATE_LINK, SCORE_RULE_4A_DOWNLOAD_LINK_BONUS,
   SCORE_RULE_4B_DOWNLOAD_BTN, SCORE_RULE_4B_FILE_LINK, SCORE_RULE_4B_ARCHIVE_LINK,
@@ -56,8 +56,8 @@ export class ScoringEngine {
    */
   static async evaluate(ctx) {
     const {
-      url, domain, pageText, icpStrings, linkMetrics,
-      downloadState, pageMetrics
+      url, domain, pageText, icpStrings, hasIcpGovLink,
+      linkMetrics, downloadState, pageMetrics
     } = ctx;
 
     // 规则一：域名仿冒检测
@@ -65,7 +65,7 @@ export class ScoringEngine {
     const existingScore = result1.score;
 
     // 规则三：ICP检测
-    const result3 = this._evaluateRule3(domain, pageText, icpStrings);
+    const result3 = this._evaluateRule3(domain, pageText, icpStrings, hasIcpGovLink);
 
     // 优化：域名检测和ICP检测均确认安全 → 跳过规则四/五（官方网站早期退出）
     const isConfirmedOfficial = (
@@ -204,19 +204,23 @@ export class ScoringEngine {
 
   // ==================== 规则三：ICP备案号缺失 (50分) ====================
   /**
-   * ICP 备案检测。
+   * 规则三：ICP备案检测（≤50分）
    *
-   * 判定链路（不再依赖域名推测国籍）：
-   *   1. 官方域名                       → 跳过（0 分）
-   *   2. 页面中找到 ICP 备案号           → 安全（0 分）
-   *   3. 未找到且站点在外国豁免白名单中    → 跳过（0 分，确定无需备案）
-   *   4. 未找到但页面有显著中文内容       → +50 分（中国站点缺少备案）
-   *   5. 未找到、不在白名单、也无中文内容  → +20 分（弱信号，不确定）
+   * 判定链路：
+   *   1. 官方域名                          → 0  PASS
+   *   2a. ICP + 非黑名单 + 可点击政府链接    → 0  PASS（已核验）
+   *   2b. ICP + 缺政府链接 且 页有中文       → +50 TRIGGERED（虚假备案嫌疑）
+   *   2c. ICP + 缺政府链接 且 无中文         → +30 TRIGGERED（虚假备案嫌疑）
+   *   2d. ICP 号码在黑名单中                → 同 2b/2c（按有无中文判定）
+   *   3.  无 ICP + 豁免白名单               → 0  NEUTRAL
+   *   4.  无 ICP + 有中文                   → +50 TRIGGERED
+   *   5.  无 ICP + 无中文 + 非白名单         → +20 WARN
    */
-  static _evaluateRule3(domain, pageText, icpStrings) {
+  static _evaluateRule3(domain, pageText, icpStrings, hasIcpGovLink) {
     const result = {
       score: 0, triggered: false,
-      detail: '', detailCN: '', icpFound: false, icpNumbers: []
+      detail: '', detailCN: '', icpFound: false, icpNumbers: [],
+      icpVerified: false, icpBlacklisted: false
     };
 
     // 1. 官方域名本尊 → 跳过
@@ -228,19 +232,49 @@ export class ScoringEngine {
       return result;
     }
 
-    // 2. 搜索 ICP 备案号
+    // 2. 搜索 ICP 备案号（含真实验证）
     const icpResult = IcpUtils.searchIcpNumber(pageText, icpStrings);
 
     if (icpResult.found) {
-      result.status = 'pass';
+      const realNumbers = icpResult.numbers.filter(n => !IcpUtils.isBlacklistedIcp(n));
+      const hasBlacklisted = realNumbers.length < icpResult.numbers.length;
+      result.icpBlacklisted = hasBlacklisted;
+
+      // 2a. 真实验证通过 → 完全安全
+      if (realNumbers.length > 0 && hasIcpGovLink) {
+        result.status = 'pass';
+        result.icpFound = true;
+        result.icpVerified = true;
+        result.icpNumbers = realNumbers;
+        result.detail = `检测到ICP备案号: ${realNumbers[0]}（已核验）`;
+        result.detailCN = `ICP备案: 已检测到 (${realNumbers[0]})`;
+        return result;
+      }
+
+      // 2b/2c/2d: ICP 存在但不可核验 → 可疑行为，直接加分
       result.icpFound = true;
-      result.icpNumbers = icpResult.numbers;
-      result.detail = `检测到ICP备案号: ${icpResult.numbers[0]}`;
-      result.detailCN = `ICP备案: 已检测到 (${icpResult.numbers[0]})`;
-      return result;
+      if (realNumbers.length > 0) result.icpNumbers = realNumbers;
+
+      // 根据中文内容判定分数
+      const cjkResult = IcpUtils.detectCJKContent(pageText);
+      if (cjkResult.hasCJK) {
+        result.score = SCORE_RULE_3;  // +50 — 中文站用虚假/未核验备案
+        result.triggered = true;
+        let reason = result.icpBlacklisted ? '备案号疑似虚假' : '备案号缺少可点击核验链接';
+        result.detail = `ICP备案疑似虚假（域名${domain}，${reason}，页面含${cjkResult.cjkCount}个中文字符）`;
+        result.detailCN = `ICP备案: 虚假/未核验（${reason}）`;
+        return result;
+      } else {
+        result.score = SCORE_RULE_3_FAKE;  // +30 — 无中文但显示了虚假备案号
+        result.triggered = true;
+        let reason = result.icpBlacklisted ? '备案号疑似虚假' : '备案号缺少可点击核验链接';
+        result.detail = `ICP备案疑似虚假（域名${domain}，${reason}，页面无中文内容）`;
+        result.detailCN = `ICP备案: 虚假/未核验（${reason}）`;
+        return result;
+      }
     }
 
-    // 3. 未找到 → 判定是否需要备案
+    // 3. 未找到 ICP → 判定是否需要备案
     // 3a. 外国站点豁免白名单 → 确定不需要 ICP
     if (IcpUtils.isIcpExempt(domain)) {
       result.status = 'neutral';
@@ -255,7 +289,7 @@ export class ScoringEngine {
       result.score = SCORE_RULE_3;  // +50
       result.triggered = true;
       result.detail = `未检测到ICP备案号（域名${domain}，页面含${cjkResult.cjkCount}个中文字符，占比${(cjkResult.cjkRatio * 100).toFixed(1)}%）`;
-      result.detailCN = `ICP备案: 未检测到备案号`;
+      result.detailCN = 'ICP备案: 未检测到备案号';
       return result;
     }
 
@@ -263,7 +297,7 @@ export class ScoringEngine {
     result.score = 20;
     result.status = 'warn';
     result.detail = `无中文内容且非已知外国站点（域名${domain}），缺少ICP为弱信号`;
-    result.detailCN = `ICP备案: 未检测到备案号（弱信号）`;
+    result.detailCN = 'ICP备案: 未检测到备案号（弱信号）';
 
     return result;
   }

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -542,6 +542,7 @@ async function analyzePage(tabId, url, domain, pageMetrics, linkMetrics) {
     domain: tabState.domain || domain,
     pageText: tabState.pageText || '',
     icpStrings: tabState.icpStrings || [],
+    hasIcpGovLink: tabState.hasIcpGovLink || false,
     linkMetrics: linkMetrics || tabState.linkMetrics || null,
     downloadState: tabState.downloadState || { hasDownloadedArchive: false },
     pageMetrics: pageMetrics || tabState.pageMetrics || null
@@ -745,7 +746,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case 'PAGE_ANALYSIS_RESULT': {
       const tabId = sender.tab ? sender.tab.id : null;
       if (!tabId) { sendResponse({ received: false }); return false; }
-      const { url, domain, pageText, icpStrings, pageMetrics, linkMetrics } = message.payload;
+      const { url, domain, pageText, icpStrings, pageMetrics, linkMetrics, hasIcpGovLink } = message.payload;
 
       // 竞态条件防护：校验 content script 所在标签页的当前 URL 是否与采集数据的域名一致
       // 若用户已导航到其他页面，则丢弃此消息（旧页面的数据不应污染新页面的检测结果）
@@ -767,6 +768,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       loadTabState(tabId).then(async (ts) => {
         ts.pageText = pageText || '';
         ts.icpStrings = icpStrings || [];
+        ts.hasIcpGovLink = !!hasIcpGovLink;
         ts.url = url || ts.url;
         ts.domain = domain || ts.domain;
         if (pageMetrics) ts.pageMetrics = pageMetrics;

--- a/content/content-script.js
+++ b/content/content-script.js
@@ -502,6 +502,20 @@
     return icpStrings;
   }
 
+  /**
+   * 检测页面是否存在可点击的工信部备案查询链接
+   * 检查 <a> 标签 href 是否指向 beian.miit.gov.cn 等政府备案域名
+   * @returns {boolean}
+   */
+  function checkIcpGovLink() {
+    try {
+      var links = document.querySelectorAll('a[href*="beian.miit.gov.cn"], a[href*="beian.gov.cn"], a[href*="miitbeian.gov.cn"]');
+      return links.length > 0;
+    } catch (e) {
+      return false;
+    }
+  }
+
   // ==================== 发送分析结果 ====================
 
   function safeCollect(fn, fallback) {
@@ -523,10 +537,12 @@
       console.error('[VirusDetector] 链接分析采集失败:', e);
     }
 
+    var hasIcpGovLink = checkIcpGovLink();
     var payload = {
       url: window.location.href, domain: window.location.hostname, title: document.title,
       pageText: safeCollect(function() { return (document.body ? document.body.innerText : '').substring(0, 15000); }, ''),
-      icpStrings: icpStrings, pageMetrics: pageMetrics, linkMetrics: linkMetrics
+      icpStrings: icpStrings, pageMetrics: pageMetrics, linkMetrics: linkMetrics,
+      hasIcpGovLink: hasIcpGovLink
     };
 
     // 二次扫描去重：与首次结果比对，无新增数据则跳过发送
@@ -573,6 +589,7 @@
             pageMetrics: safeCollect(collectPageMetrics, null),
             linkMetrics: linkMetrics,
             icpStrings: safeCollect(findIcpStrings, []),
+            hasIcpGovLink: checkIcpGovLink(),
             pageText: (document.body ? document.body.innerText : '').substring(0, 15000),
             title: document.title,
             url: window.location.href

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -444,6 +444,40 @@ body {
   color: var(--text2);
 }
 
+/* ===== ICP 备案核验 ===== */
+.icp-query-link {
+  display: inline-block;
+  margin-left: 20px;
+  font-size: 11px;
+  color: #1976D2;
+  text-decoration: none;
+  cursor: pointer;
+}
+.icp-query-link:hover {
+  text-decoration: underline;
+  color: #1565C0;
+}
+
+.icp-verify-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 0 6px;
+  font-size: 10px;
+  line-height: 16px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+.icp-verify-badge.badge-fake {
+  background: #ffebee;
+  color: #c62828;
+  border: 1px solid #ef9a9a;
+}
+.icp-verify-badge.badge-unverified {
+  background: #fff3e0;
+  color: #e65100;
+  border: 1px solid #ffcc80;
+}
+
 /* ===== Safety Tips ===== */
 #safety-tips {
   background: var(--red-light);

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -275,6 +275,39 @@
         textEl.textContent = rule.detailCN;
         textEl.className = 'detail-text passed';
       }
+
+      // —— ICP 备案号核验状态与查询链接 ——
+      if (key === 'rule3') {
+        // 移除旧的核验元素
+        const oldBadge = el.querySelector('.icp-verify-badge');
+        const oldLink = el.querySelector('.icp-query-link');
+        if (oldBadge) oldBadge.remove();
+        if (oldLink) oldLink.remove();
+
+        if (rule && rule.icpVerified && rule.icpNumbers && rule.icpNumbers.length > 0) {
+          // 已核验 → 显示工信部查询链接
+          textEl.textContent = `ICP备案: 已检测到 (${rule.icpNumbers[0]})`;
+          const linkEl = document.createElement('a');
+          linkEl.className = 'icp-query-link';
+          linkEl.href = 'https://beian.miit.gov.cn/';
+          linkEl.target = '_blank';
+          linkEl.rel = 'noopener noreferrer';
+          linkEl.textContent = '工信部查询 ›';
+          el.appendChild(linkEl);
+        } else if (rule && rule.icpBlacklisted) {
+          // 备案号疑似虚假
+          const badge = document.createElement('span');
+          badge.className = 'icp-verify-badge badge-fake';
+          badge.textContent = '虚假备案';
+          el.appendChild(badge);
+        } else if (rule && rule.icpFound && !rule.icpVerified) {
+          // 已找到但未核验
+          const badge = document.createElement('span');
+          badge.className = 'icp-verify-badge badge-unverified';
+          badge.textContent = '未核验';
+          el.appendChild(badge);
+        }
+      }
     }
   }
 

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -17,6 +17,7 @@ export const SCORE_RULE_1 = 60;              // 规则一：域名仿冒
 export const SCORE_RULE_2_HIGH = 40;         // 规则二：压缩包下载（域名已有≥30嫌疑）
 export const SCORE_RULE_2_LOW = 10;          // 规则二：压缩包下载（弱信号）
 export const SCORE_RULE_3 = 50;             // 规则三：ICP备案号缺失（所有网站）
+export const SCORE_RULE_3_FAKE = 30;        // 规则三：ICP备案号存在但无法核验（无政府链接/虚假号码）
 
 // 规则四：链接分析（替代证书检测）
 export const SCORE_RULE_4A_SAME_PAGE = 20;      // 规则四A-① ≥3个链接指向当前页本身（完全一致URL）


### PR DESCRIPTION
- icp-utils: 新增 ICP 黑名单，自动生成31个省级行政区×ICP备/证×2种后缀 共124个占位号码；额外检测全零数字； isBlacklistedIcp() 支持动态判定
- content-script: 新增 checkIcpGovLink() 检测页面是否存在可点击的 beian.miit.gov.cn / beian.gov.cn 政府备案链接；以 hasIcpGovLink 标志随 PAGE_ANALYSIS_RESULT 和 REQUEST_PAGE_TEXT 消息传递
- service-worker: 接收并存储 hasIcpGovLink 到 tabState，传入评分引擎
- scoring-engine: _evaluateRule3 集成验真评分逻辑： · 有备案号+有链接+非黑名单 → 0分 已核验 · 有备案号但无链接/黑名单+有中文 → +50分 虚假备案嫌疑 · 有备案号但无链接/黑名单+无中文 → +30分 虚假备案嫌疑 · 无备案号+豁免 → 0分 不适用 · 无备案号+有中文 → +50分 · 无备案号+无中文 → +20分 弱信号
- constants: 新增 SCORE_RULE_3_FAKE = 30 常量
- popup: 已核验显示「工信部查询」可点击链接； 黑名单显示「虚假备案」红色标签； 未核验显示「未核验」橙色标签

本 PR 解决 Closes #20 