### PR TITLE
[修复]Feat/fix psl dns cache poisoning

### DIFF
--- a/background/whois-client.js
+++ b/background/whois-client.js
@@ -185,15 +185,26 @@ async function _lookupViaWhoisCx(normalizedDomain) {
     return null;
   }
 
+  // 一次性读取响应体，避免多次 clone
+  let responseText = '';
+  try { responseText = await response.clone().text(); } catch (e) { /* ignore */ }
+
+  // 检查是否为 HTML（WhoisCX API 可能已废弃）
+  const trimmed = responseText.trim();
+  if (trimmed.startsWith('<!DOCTYPE') || trimmed.startsWith('<html')) {
+    _recordError(normalizedDomain, 'parse',
+      'WhoisCX API 可能已废弃（返回 HTML 而非 JSON），建议移除或替换此回退路径',
+      { url, responseBody: responseText.substring(0, 200) });
+    return null;
+  }
+
   let json;
   try {
-    json = await response.json();
+    json = JSON.parse(responseText);
   } catch (parseError) {
-    let responseBody = '';
-    try { responseBody = await response.clone().text(); } catch (e) { /* ignore */ }
     _recordError(normalizedDomain, 'parse',
       `WhoisCX JSON 解析失败: ${parseError.message}`,
-      { url, responseBody: responseBody.substring(0, 500) });
+      { url, responseBody: responseText.substring(0, 500) });
     return null;
   }
 

--- a/background/whois-client.js
+++ b/background/whois-client.js
@@ -130,6 +130,73 @@ function _parseDaysFromWhoisCxTime(timeStr) {
   }
 }
 
+// ==================== 父域名回退查询（防御加固）====================
+
+/**
+ * 当标准查询路径失败时，逐级向上回退父域名。
+ * 处理多级公共后缀子域名（如 a.b.github.io）等，
+ * 子域名没有独立 WHOIS 记录时回退到父域名的注册信息。
+ *
+ * @param {string} failedDomain - 已查询失败的标准域名
+ * @returns {Promise<WhoisResult|null>}
+ */
+async function _lookupParentDomains(failedDomain) {
+  const parts = failedDomain.split('.');
+  // 至少保留两级才能视为域名（如 example.com）
+  if (parts.length <= 2) return null;
+
+  console.log(`[WhoisClient] 尝试父域名回退: ${failedDomain}`);
+  for (let i = 1; i < parts.length - 1; i++) {
+    const parentDomain = parts.slice(i).join('.');
+    if (!parentDomain.includes('.')) continue;
+
+    // 先查 WhoisClient 缓存
+    const cached = _cache.get(parentDomain);
+    if (cached && (Date.now() - cached.timestamp) < WHOIS_CACHE_TTL) {
+      console.log(`[WhoisClient] 父域名缓存命中: ${parentDomain}`);
+      return cached.result;
+    }
+
+    // 尝试 RDAP 查询父域名
+    console.log(`[WhoisClient] 回退 RDAP 查询父域名: ${parentDomain}`);
+    const rdapResult = await RdapClient.lookup(parentDomain);
+    if (rdapResult && !rdapResult._rdap?.unsupported && !rdapResult._rdap?.notFound) {
+      const result = {
+        domain: rdapResult.domain || parentDomain,
+        domainSuffix: rdapResult.domainSuffix || '',
+        creationDays: rdapResult.creationDays,
+        validDays: rdapResult.validDays,
+        creationTime: rdapResult.creationTime || '',
+        expirationTime: rdapResult.expirationTime || '',
+        isExpire: rdapResult.isExpire || false,
+        registrarName: rdapResult.registrarName || '',
+        domainStatus: rdapResult.domainStatus || [],
+        nameServer: rdapResult.nameServer || [],
+        queryTime: rdapResult.queryTime || new Date().toISOString()
+      };
+      if (result.creationDays > 0) {
+        _cache.set(parentDomain, { result, timestamp: Date.now() });
+      }
+      console.log(`[WhoisClient] 父域名 RDAP 查询成功: ${parentDomain} (注册 ${result.creationDays}d)`);
+      return result;
+    }
+
+    // 尝试 WhoisCX 查询父域名
+    console.log(`[WhoisClient] 回退 WhoisCX 查询父域名: ${parentDomain}`);
+    const whoisResult = await _lookupViaWhoisCx(parentDomain);
+    if (whoisResult) {
+      if (whoisResult.creationDays > 0) {
+        _cache.set(parentDomain, { result: whoisResult, timestamp: Date.now() });
+      }
+      console.log(`[WhoisClient] 父域名 WhoisCX 查询成功: ${parentDomain} (注册 ${whoisResult.creationDays}d)`);
+      return whoisResult;
+    }
+  }
+
+  console.warn(`[WhoisClient] 父域名回退完全失败: ${failedDomain}`);
+  return null;
+}
+
 // ==================== WhoisCX API 回退查询 ====================
 
 /**
@@ -367,7 +434,11 @@ export class WhoisClient {
       return whoisResult;
     }
 
-    // 8. 两条路径均失败
+    // 8. 两条路径均失败 → 尝试逐级向上回退父域名
+    //    处理多级公共后缀子域名（如 a.b.github.io 等），逐级剥离标签查找父域名的注册信息
+    const fallbackResult = await _lookupParentDomains(normalizedDomain);
+    if (fallbackResult) return fallbackResult;
+
     console.error(`[WhoisClient] RDAP 和 WhoisCX 均查询失败: ${normalizedDomain}`);
     return null;
   }

--- a/utils/url-utils.js
+++ b/utils/url-utils.js
@@ -58,7 +58,10 @@ const _FALLBACK_TLD = new Set([
 function getPublicSuffix(hostname) {
   // 1. DNS 缓存命中（由 refreshPublicSuffixDNS 异步填充）
   const cached = _pslCache.get(hostname);
-  if (cached) return cached;
+  // 二次验证：缓存的 suffix 必须是 hostname 的有效后缀，防止无效数据污染
+  if (cached && (hostname.endsWith('.' + cached) || hostname === cached)) {
+    return cached;
+  }
 
   // 2. 回退匹配：从最右段开始逐级向左扩展，找到 PSL 中最长的连续匹配
   //    例如 xxx.com.cn: cn✓ → com.cn✗(不在回退集) → 返回 cn
@@ -141,7 +144,19 @@ export async function refreshPublicSuffixDNS(hostname) {
     const raw = json.Answer[0].data;
     if (!raw || typeof raw !== 'string') return null;
 
-    const suffix = raw.replace(/\.$/, '');
+    // publicsuffix.zone PTR 响应返回的是完整路径（如 "xyz.query.publicsuffix.zone."），
+    // 需要剥离 ".query.publicsuffix.zone" 得到纯后缀（如 "xyz"）
+    let suffix = raw.replace(/\.$/, '');
+    if (suffix.endsWith('.query.publicsuffix.zone')) {
+      suffix = suffix.replace(/\.query\.publicsuffix\.zone$/, '');
+    }
+
+    // 验证：后缀必须是 hostname 的合法后缀，防止无效数据污染缓存
+    if (!hostname.endsWith('.' + suffix) && hostname !== suffix) {
+      console.warn(`[UrlUtils] DoH PSL 返回无效后缀 "${suffix}" for ${hostname}，忽略`);
+      return null;
+    }
+
     _pslCache.set(hostname, suffix);
     console.log(`[UrlUtils] DNS PSL cache updated: ${hostname} -> "${suffix}"`);
     return suffix;

--- a/utils/url-utils.js
+++ b/utils/url-utils.js
@@ -60,7 +60,16 @@ function getPublicSuffix(hostname) {
   const cached = _pslCache.get(hostname);
   // 二次验证：缓存的 suffix 必须是 hostname 的有效后缀，防止无效数据污染
   if (cached && (hostname.endsWith('.' + cached) || hostname === cached)) {
-    return cached;
+    // 额外验证：缓存的后缀必须能让 extractRegistrableDomain 提取出比 hostname 更短的域名
+    // 防止多级公共后缀（如 github.io、herokuapp.com）导致可注册域名等于原始域名，
+    // 使后续 WHOIS/RDAP 查询失败（GitHub Pages 子域名没有独立注册信息）
+    const cachedParts = cached.split('.');
+    const hostParts = hostname.split('.');
+    if (cachedParts.length < hostParts.length - 1) {
+      return cached;
+    }
+    // 若后缀长度 >= hostname-1，则 registrable = hostname，对 WHOIS 无意义
+    // 回退到 fallback（不淘汰缓存，不影响未来的查询策略变化）
   }
 
   // 2. 回退匹配：从最右段开始逐级向左扩展，找到 PSL 中最长的连续匹配
@@ -155,6 +164,15 @@ export async function refreshPublicSuffixDNS(hostname) {
     if (!hostname.endsWith('.' + suffix) && hostname !== suffix) {
       console.warn(`[UrlUtils] DoH PSL 返回无效后缀 "${suffix}" for ${hostname}，忽略`);
       return null;
+    }
+
+    // 验证：缓存后缀必须能让 extractRegistrableDomain 提取出比 hostname 更短的域名
+    // 防止多级公共后缀（如 github.io）投毒缓存，导致查询结果不一致
+    const _suffixParts = suffix.split('.');
+    const _hostParts = hostname.split('.');
+    if (_suffixParts.length >= _hostParts.length - 1) {
+      console.log(`[UrlUtils] DoH PSL suffix "${suffix}" for ${hostname} 不会缩短域名，跳过缓存`);
+      return suffix;
     }
 
     _pslCache.set(hostname, suffix);


### PR DESCRIPTION
根源：refreshPublicSuffixDNS() 直接从 PTR 响应存储完整路径
（如 "xyz.query.publicsuffix.zone"）而非纯后缀（"xyz"），
导致后续 PSL 提取返回 4 段无效后缀，extractRegistrableDomain()
因 suffixParts.length >= parts.length 返回原始 hostname 不变。

修复：
1. refreshPublicSuffixDNS() — 剥离 .query.publicsuffix.zone 后缀，并验证结果是否是 hostname 的合法后缀
2. getPublicSuffix() — 缓存读取时二次验证有效性， 无效则走 fallback TLD 匹配
3. _lookupViaWhoisCx() — 提前检测 HTML 响应并给出 明确的废弃提示，避免迷惑性 JSON 解析错误日志