### PR TITLE
新增了minecraft.wiki域名作为官方域名

### DIFF
--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -874,7 +874,7 @@ const DOMAIN_DATABASE = [
   },
   {
     name: 'Minecraft',
-    officialDomains: ['minecraft.net', 'mojang.com'],
+    officialDomains: ['minecraft.net', 'minecraft.wiki', 'mojang.com'],
     correctUrl: 'https://www.minecraft.net',
     category: SOFTWARE_CATEGORIES.GAME,
     keywords: ['Minecraft', 'minecraft', '我的世界', 'Mojang'],


### PR DESCRIPTION
没有将所有.wiki域名都列进来，因为容易误识别，并且很多Wiki百科网站在其网址中并不使用.wiki