### PR TITLE
fix: ICP核验链接检测遗漏公安部备案域名 beian.mps.gov.cn

### DIFF
--- a/content/content-script.js
+++ b/content/content-script.js
@@ -569,7 +569,7 @@
    */
   function checkIcpGovLink() {
     try {
-      var links = document.querySelectorAll('a[href*="beian.miit.gov.cn"], a[href*="beian.gov.cn"], a[href*="miitbeian.gov.cn"]');
+      var links = document.querySelectorAll('a[href*="beian.miit.gov.cn"], a[href*="beian.gov.cn"], a[href*="miitbeian.gov.cn"], a[href*="beian.mps.gov.cn"]');
       return links.length > 0;
     } catch (e) {
       return false;


### PR DESCRIPTION
在这个[网站](https://www.sqgxy.edu.cn/)测试无法通过 ICP备案,缺少匹配域名
a标签为
```html
<a href="https://beian.mps.gov.cn/#/query/webSearch" target="_blank">豫公网安备 41140302000028号</a>
```