### PR TITLE
fix: avoid interfering with authentication flows

### DIFF
--- a/background/domain-database.js
+++ b/background/domain-database.js
@@ -809,6 +809,14 @@ const DOMAIN_DATABASE = [
     keywords: ['Github', 'GitHub'],
     isChineseBrand: false
   },
+  {
+    name: 'GitLab',
+    officialDomains: ['gitlab.com'],
+    correctUrl: 'https://gitlab.com',
+    category: SOFTWARE_CATEGORIES.DEVELOPER,
+    keywords: ['GitLab', 'gitlab'],
+    isChineseBrand: false
+  },
 // ========== 系统工具 ==========
   {
     name: '驱动精灵',

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -58,6 +58,19 @@ function shouldSkipUrl(url) {
   }
 }
 
+const AUTH_HOST_PATTERN = /^(login|logon|signin|auth|oauth|account|accounts|identity|id|sso|secure|security|verify|verification|console)\./i;
+const AUTH_PATH_PATTERN = /(?:^|[\/?#&=._-])(login|logon|logout|signin|sign-in|signout|sign-out|auth|oauth|authorize|sso|saml|2fa|mfa|otp|totp|challenge|verify|verification|webauthn|passkey|password|credential|credentials|session|callback|consent|recover|recovery|reset|device)(?:$|[\/?#&=._-])/i;
+
+function isSensitiveAuthenticationUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (AUTH_HOST_PATTERN.test(parsed.hostname)) return true;
+    return AUTH_PATH_PATTERN.test(parsed.pathname + parsed.search + parsed.hash);
+  } catch (e) {
+    return false;
+  }
+}
+
 // ==================== 全局设置缓存 ====================
 
 /** 内存缓存：避免每次评分都读取 storage */
@@ -391,6 +404,7 @@ async function loadGlobalSettings() {
 
 // 去重：每个标签页的警告冷却期（5秒内不重复弹窗）
 const _warningCooldown = new Map();
+const _authenticationTabs = new Set();
 const WARNING_COOLDOWN_MS = 5000;
 
 /**
@@ -464,6 +478,13 @@ async function triggerWarningFlow(tabId, tabState) {
 async function injectDownloadBlocker(tabId, archiveUrls = []) {
   const settings = await loadGlobalSettings();
   try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!tab.url || _authenticationTabs.has(tabId) ||
+        isSensitiveAuthenticationUrl(tab.url) || await isWhitelisted(tab.url)) {
+      await removeDownloadBlocker(tabId);
+      return;
+    }
+
     await chrome.scripting.executeScript({
       target: { tabId },
       func: injectBlockerFunc,
@@ -475,6 +496,47 @@ async function injectDownloadBlocker(tabId, archiveUrls = []) {
   }
 }
 
+async function removeDownloadBlocker(tabId) {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: removeDownloadBlockerFunc,
+      injectImmediately: true
+    });
+  } catch (e) {
+    // 页面可能已关闭或不允许脚本注入。
+  }
+}
+
+async function removeBlockersFromWhitelistedTabs() {
+  const tabs = await chrome.tabs.query({});
+  await Promise.all(tabs.map(async (tab) => {
+    if (!tab.id || !tab.url || !await isWhitelisted(tab.url)) return;
+    await removeDownloadBlocker(tab.id);
+    setIconWhitelist(tab.id);
+  }));
+}
+
+function removeDownloadBlockerFunc() {
+  const state = window.__virusDetectorBlockerState;
+  if (!state) return;
+
+  if (state.anchorClick && HTMLAnchorElement.prototype.click === state.patchedAnchorClick) {
+    HTMLAnchorElement.prototype.click = state.anchorClick;
+  }
+  if (state.createElement && document.createElement === state.patchedCreateElement) {
+    document.createElement = state.createElement;
+  }
+  if (state.clickHandler) {
+    document.removeEventListener('click', state.clickHandler, true);
+  }
+  if (state.observer) state.observer.disconnect();
+  if (state.overlay?.isConnected) state.overlay.remove();
+
+  delete window.__virusDetectorBlockerState;
+  delete window.__virusDetectorInjected;
+}
+
 /**
  * 注入到页面的拦截函数（独立定义以支持 args 传递）
  * @param {string[]} archiveUrls - 已知压缩包链接
@@ -484,7 +546,17 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
   detectNonArchive = detectNonArchive || false;
 
   // 避免重复注入
-  if (window.__virusDetectorInjected) return;
+  if (window.__virusDetectorBlockerState || window.__virusDetectorInjected) return;
+  var blockerState = {
+    anchorClick: null,
+    patchedAnchorClick: null,
+    createElement: null,
+    patchedCreateElement: null,
+    clickHandler: null,
+    observer: null,
+    overlay: null
+  };
+  window.__virusDetectorBlockerState = blockerState;
   window.__virusDetectorInjected = true;
 
   // ══════════════════════════════════════════════════════
@@ -510,7 +582,7 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
   // 当任何脚本调用 a.click() 程式化触发下载时拦截
   try {
     var _origAnchorClick = HTMLAnchorElement.prototype.click;
-    HTMLAnchorElement.prototype.click = function () {
+    var _patchedAnchorClick = function () {
       var href = this.href || this.getAttribute('href') || '';
       if (href && _isDangerousHref(href)) {
         // 弹确认窗
@@ -528,14 +600,17 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
       }
       return _origAnchorClick.call(this);
     };
+    blockerState.anchorClick = _origAnchorClick;
+    blockerState.patchedAnchorClick = _patchedAnchorClick;
+    HTMLAnchorElement.prototype.click = _patchedAnchorClick;
   } catch (e) { /* prototype hook 失败时静默降级 */ }
 
   // --- Hook 2: 拦截 document.createElement ---
   // 监控程序化创建的 <a> 元素，设置 href 时检查
   try {
-    var _origCreateElement = document.createElement.bind(document);
-    document.createElement = function (tagName, options) {
-      var el = _origCreateElement(tagName, options);
+    var _origCreateElement = document.createElement;
+    var _patchedCreateElement = function (tagName, options) {
+      var el = _origCreateElement.call(document, tagName, options);
       if (tagName && tagName.toLowerCase() === 'a') {
         // 对动态创建的 <a> 元素，hook 其 href setter
         var _origSetAttribute = el.setAttribute.bind(el);
@@ -568,6 +643,9 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
       }
       return el;
     };
+    blockerState.createElement = _origCreateElement;
+    blockerState.patchedCreateElement = _patchedCreateElement;
+    document.createElement = _patchedCreateElement;
   } catch (e) { /* createElement hook 失败时静默降级 */ }
 
   // ══════════════════════════════════════════════════════
@@ -693,7 +771,7 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
   // Part 4: 全局点击拦截 — 双层（新版精准 + 旧版宽泛）
   // ══════════════════════════════════════════════════════
 
-  document.addEventListener('click', function(e) {
+  var _clickHandler = function(e) {
     var target = e.target.closest('a, button, [role="button"], [onclick]');
     if (!target) return;
 
@@ -751,7 +829,9 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
       }
       return false;
     }
-  }, true);
+  };
+  blockerState.clickHandler = _clickHandler;
+  document.addEventListener('click', _clickHandler, true);
 
   // ══════════════════════════════════════════════════════
   // Part 5: MutationObserver 动态监控（旧版能力）
@@ -760,6 +840,7 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
   var observer = new MutationObserver(function() {
     disableExistingDownloadButtons();
   });
+  blockerState.observer = observer;
 
   if (document.body) {
     observer.observe(document.body, { childList: true, subtree: true });
@@ -783,6 +864,7 @@ function injectBlockerFunc(archiveUrls, detectNonArchive) {
       '⚠️ 风险警告：该网站被检测为疑似钓鱼/恶意网站，请勿输入个人信息或下载任何文件！' +
       '</div>';
     document.documentElement.appendChild(overlay);
+    blockerState.overlay = overlay;
   }
 }
 
@@ -1033,10 +1115,12 @@ async function analyzePage(tabId, url, domain, pageMetrics, linkMetrics) {
  */
 async function _applyWhoisUpdate(ctx, whoisResult) {
   const { domain, tabId, syncScore, syncBreakdown, correctUrl, officialName } = ctx;
+  let currentUrl = '';
 
   // 竞态条件检查：用户是否已导航到其他页面
   try {
     const tab = await chrome.tabs.get(tabId);
+    currentUrl = tab.url || '';
     const currentDomain = UrlUtils.extractHostname(tab.url || '');
     if (currentDomain !== domain) {
       console.log('[ServiceWorker] Whois结果过期（用户已导航）:', domain, '→', currentDomain);
@@ -1045,6 +1129,12 @@ async function _applyWhoisUpdate(ctx, whoisResult) {
   } catch (e) {
     // 标签页已关闭
     console.log('[ServiceWorker] Whois结果过期（标签页已关闭）:', tabId);
+    return;
+  }
+
+  if (await isWhitelisted(currentUrl)) {
+    await removeDownloadBlocker(tabId);
+    setIconWhitelist(tabId);
     return;
   }
 
@@ -1152,6 +1242,11 @@ async function _postReportToWorker(reportType, domain, note) {
 }
 
 // ==================== 事件监听 ====================
+
+// 新文档提交后清除上一个页面的认证交互标记；当前页面的 Content Script 会按需重新标记。
+chrome.webNavigation.onCommitted.addListener((details) => {
+  if (details.frameId === 0) _authenticationTabs.delete(details.tabId);
+});
 
 // 页面导航完成
 chrome.webNavigation.onCompleted.addListener(async (details) => {
@@ -1392,6 +1487,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const type = message.type;
 
   switch (type) {
+    case 'AUTH_INTERACTION_DETECTED': {
+      const tabId = sender.tab ? sender.tab.id : null;
+      if (!tabId) { sendResponse({ received: false }); return false; }
+      _authenticationTabs.add(tabId);
+      removeDownloadBlocker(tabId).then(() => {
+        sendResponse({ received: true });
+      });
+      return true;
+    }
+
     case MSG_TYPES.PAGE_ANALYSIS_RESULT:
     case 'PAGE_ANALYSIS_RESULT': {
       const tabId = sender.tab ? sender.tab.id : null;
@@ -1480,6 +1585,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         const url = message.payload?.url || '';
         if (url) {
           await addToWhitelist(url);
+          await removeDownloadBlocker(tabs[0].id);
           // 更新当前标签页状态
           const ts = await loadTabState(tabs[0].id);
           ts.isWhitelisted = true;
@@ -1721,8 +1827,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case 'BULK_UPDATE_WHITELIST':
     case MSG_TYPES.BULK_UPDATE_WHITELIST: {
       const domains = (message.payload && message.payload.domains) ? message.payload.domains : [];
-      saveWhitelist(domains).then(() => {
+      saveWhitelist(domains).then(async () => {
         _whitelistCache = new Set(domains);
+        await removeBlockersFromWhitelistedTabs();
         console.log('[ServiceWorker] 白名单已批量更新:', domains.length, '个域名');
         sendResponse({ success: true, count: domains.length });
       }).catch(e => {
@@ -1779,6 +1886,7 @@ chrome.notifications.onButtonClicked.addListener(async (notifId, btnIdx) => {
 chrome.tabs.onRemoved.addListener(async (tabId) => {
   await clearTabState(tabId);
   _warningCooldown.delete(tabId);
+  _authenticationTabs.delete(tabId);
 });
 
 // 安装/更新

--- a/content/content-script.js
+++ b/content/content-script.js
@@ -36,6 +36,108 @@
     'portable', 'release', 'full version'
   ];
 
+  const AUTH_URL_PATTERN = /(?:^|[\/?#&=._-])(login|logon|logout|signin|sign-in|signout|sign-out|auth|oauth|authorize|sso|saml|2fa|mfa|otp|totp|challenge|verify|verification|webauthn|passkey|password|credential|credentials|session|callback|consent|recover|recovery|reset|device)(?:$|[\/?#&=._-])/i;
+  const AUTH_HOST_PATTERN = /^(login|logon|signin|auth|oauth|account|accounts|identity|id|sso|secure|security|verify|verification|console)\./i;
+  const AUTH_INTERACTION_PATTERN = /(login|logon|sign\s*in|authorize|verification|verify|passkey|webauthn|2fa|mfa|otp|登录|验证码|身份验证|双重验证|两步验证)/i;
+  const DISABLE_GUARD_EVENT = 'virus-detector:disable-navigation-guard';
+  const AUTH_CONTROL_SELECTOR = [
+    'input[type="password"]',
+    'input[autocomplete="current-password"]',
+    'input[autocomplete="new-password"]',
+    'input[autocomplete="one-time-code"]',
+    'input[name*="otp"]',
+    'input[id*="otp"]',
+    'input[name*="verification"]',
+    'input[id*="verification"]'
+  ].join(',');
+
+  function isSensitiveAuthenticationUrl(url) {
+    try {
+      const parsed = new URL(url, window.location.href);
+      if (AUTH_HOST_PATTERN.test(parsed.hostname)) return true;
+      return AUTH_URL_PATTERN.test(parsed.pathname + parsed.search + parsed.hash);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function isAuthenticationPage() {
+    if (isSensitiveAuthenticationUrl(window.location.href)) return true;
+
+    try {
+      return document.querySelector(AUTH_CONTROL_SELECTOR) !== null;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async function isCurrentPageWhitelisted() {
+    try {
+      const response = await chrome.runtime.sendMessage({
+        type: 'CHECK_WHITELIST',
+        payload: { url: window.location.href }
+      });
+      return response?.isWhitelisted === true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  let _watchingAuthenticationInteraction = false;
+  let _pageInterferenceDisabled = false;
+
+  function disablePageNavigationGuard() {
+    if (_pageInterferenceDisabled) return;
+    _pageInterferenceDisabled = true;
+
+    try {
+      document.dispatchEvent(new CustomEvent(DISABLE_GUARD_EVENT));
+    } catch (e) { /* ignore */ }
+
+    chrome.runtime.sendMessage({
+      type: 'AUTH_INTERACTION_DETECTED',
+      payload: { url: window.location.href }
+    }).catch(function() {});
+
+    if (_watchingAuthenticationInteraction) {
+      document.removeEventListener('click', handleAuthenticationInteraction, true);
+      document.removeEventListener('focusin', handleAuthenticationInteraction, true);
+      _watchingAuthenticationInteraction = false;
+    }
+  }
+
+  function handleAuthenticationInteraction(event) {
+    if (!event.target || typeof event.target.closest !== 'function') return;
+    const control = event.target.closest('a, button, input, form, [role="button"]');
+    if (!control) return;
+
+    const inputType = (control.getAttribute('type') || '').toLowerCase();
+    const autocomplete = (control.getAttribute('autocomplete') || '').toLowerCase();
+    const identity = [
+      control.getAttribute('href'), control.getAttribute('action'), control.id,
+      control.getAttribute('name'), control.getAttribute('aria-label'),
+      control.textContent
+    ].filter(Boolean).join(' ');
+
+    if (inputType === 'password' || autocomplete.includes('password') ||
+        autocomplete.includes('one-time-code') || AUTH_INTERACTION_PATTERN.test(identity)) {
+      disablePageNavigationGuard();
+    }
+  }
+
+  function watchForAuthenticationInteraction() {
+    if (_watchingAuthenticationInteraction) return;
+    document.addEventListener('click', handleAuthenticationInteraction, true);
+    document.addEventListener('focusin', handleAuthenticationInteraction, true);
+    _watchingAuthenticationInteraction = true;
+  }
+
+  async function shouldSkipPageAnalysis() {
+    const whitelisted = await isCurrentPageWhitelisted();
+    if (whitelisted) disablePageNavigationGuard();
+    return whitelisted;
+  }
+
   // ==================== 规则四：链接分析数据采集 ====================
 
   /**
@@ -99,7 +201,7 @@
           if (!isInNavigationZone(link)) {
             samePageLinks++;
           }
-        } else if (resolved.hostname === currentHost) {
+        } else if (resolved.hostname === currentHost && !isSensitiveAuthenticationUrl(resolved.href)) {
           // 同域名但不同路径 → 可能是死链候选
           deadLinkCandidates.push({ href: resolvedHref, text: (link.textContent || '').trim().substring(0, 50), element: link });
         }
@@ -159,7 +261,12 @@
 
       // 并行HEAD请求（原串行for循环改为Promise.allSettled，最坏耗时从15秒降至3秒）
       var deadCheckPromises = candidatesToCheck.map(function(candidate) {
-        return fetchWithTimeout(candidate.href, { method: 'HEAD' }, 3000)
+        return fetchWithTimeout(candidate.href, {
+          method: 'HEAD',
+          credentials: 'omit',
+          referrerPolicy: 'no-referrer',
+          cache: 'no-store'
+        }, 3000)
           .then(function(resp) { return { candidate: candidate, response: resp, error: null }; })
           .catch(function(err) { return { candidate: candidate, response: null, error: err }; });
       });
@@ -991,6 +1098,10 @@
 
   async function sendAnalysisResult(options) {
     options = options || {};
+    if (await shouldSkipPageAnalysis()) return;
+
+    const authenticationPage = isAuthenticationPage();
+    if (authenticationPage) disablePageNavigationGuard();
     // 每个采集函数独立 try-catch，一个失败不影响其他
     var bodyText = safeCollect(function() { return (document.body ? document.body.innerText : '') || ''; }, '');
     var pageMetrics = safeCollect(function() { return collectPageMetrics(bodyText); }, null);
@@ -998,7 +1109,9 @@
     // 链接分析含异步HEAD请求检测死链，需await
     var linkMetrics = null;
     try {
-      linkMetrics = await collectLinkMetrics({ checkDeadLinks: options.checkDeadLinks !== false });
+      linkMetrics = await collectLinkMetrics({
+        checkDeadLinks: options.checkDeadLinks !== false && !authenticationPage
+      });
     } catch (e) {
       console.error('[VirusDetector] 链接分析采集失败:', e);
     }
@@ -1070,9 +1183,17 @@
     if (message && message.type === 'REQUEST_PAGE_TEXT') {
       (async () => {
         try {
+          if (await shouldSkipPageAnalysis()) {
+            sendResponse({ success: false, skipped: 'whitelisted' });
+            return;
+          }
+          const authenticationPage = isAuthenticationPage();
+          if (authenticationPage) disablePageNavigationGuard();
           var linkMetrics = null;
           try {
-            linkMetrics = await collectLinkMetrics({ checkDeadLinks: _cachedCheckDeadLinks });
+            linkMetrics = await collectLinkMetrics({
+              checkDeadLinks: _cachedCheckDeadLinks && !authenticationPage
+            });
           } catch (e) {
             console.error('[VirusDetector] 链接分析采集失败:', e);
           }
@@ -1114,9 +1235,14 @@
   }
 
   async function init() {
+    if (await shouldSkipPageAnalysis()) return;
+
+    watchForAuthenticationInteraction();
     // 先读取用户设置中的 checkDeadLinks 偏好，再开始扫描
     _cachedCheckDeadLinks = await getCheckDeadLinksSetting();
-    scheduleAnalysis(600, { checkDeadLinks: _cachedCheckDeadLinks });
+    const authenticationPage = isAuthenticationPage();
+    if (authenticationPage) disablePageNavigationGuard();
+    scheduleAnalysis(600, { checkDeadLinks: _cachedCheckDeadLinks && !authenticationPage });
     // 二次扫描用于捕获懒加载内容，但跳过 HEAD 死链验证以降低页面和网络成本。
     scheduleAnalysis(3500, { checkDeadLinks: false });
   }
@@ -1124,7 +1250,7 @@
   if (document.readyState === 'complete' || document.readyState === 'interactive') {
     init();
   } else {
-    window.addEventListener('load', () => scheduleAnalysis(600, { checkDeadLinks: _cachedCheckDeadLinks }));
+    window.addEventListener('load', init, { once: true });
   }
 
 })();

--- a/content/navigation-guard.js
+++ b/content/navigation-guard.js
@@ -18,6 +18,23 @@
 (function () {
   'use strict';
 
+  var AUTH_HOST_PATTERN = /^(login|logon|signin|auth|oauth|account|accounts|identity|id|sso|secure|security|verify|verification|console)\./i;
+  var AUTH_PATH_PATTERN = /(?:^|[\/?#&=._-])(login|logon|logout|signin|sign-in|signout|sign-out|auth|oauth|authorize|sso|saml|2fa|mfa|otp|totp|challenge|verify|verification|webauthn|passkey|password|credential|credentials|session|callback|consent|recover|recovery|reset|device)(?:$|[\/?#&=._-])/i;
+  var DISABLE_GUARD_EVENT = 'virus-detector:disable-navigation-guard';
+
+  function isSensitiveAuthenticationUrl(url) {
+    try {
+      var parsed = new URL(url, window.location.href);
+      if (AUTH_HOST_PATTERN.test(parsed.hostname)) return true;
+      return AUTH_PATH_PATTERN.test(parsed.pathname + parsed.search + parsed.hash);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // 登录、2FA 和控制台页面依赖原生导航对象，不在 MAIN world 中做任何 hook。
+  if (isSensitiveAuthenticationUrl(window.location.href)) return;
+
   // ==================== 危险扩展名列表 ====================
   // 与 utils/constants.js ARCHIVE_EXTENSIONS + EXECUTABLE_EXTENSIONS 保持同步
 
@@ -100,6 +117,8 @@
   // 保存原始的 location 对象引用
   var _origLocation = window.location;
   var _locationProxy = null;
+  var _origLocationSetter = null;
+  var _patchedLocationSetter = null;
 
   try {
     // 方法 A：使用 __proto__ 重写 location 对象的 href 属性
@@ -114,9 +133,9 @@
 
     if (window.__lookupSetter__ && window.__defineSetter__) {
       // 保存原始 setter
-      var _origLocationSetter = window.__lookupSetter__('location');
+      _origLocationSetter = window.__lookupSetter__('location');
       if (_origLocationSetter) {
-        window.__defineSetter__('location', function (val) {
+        _patchedLocationSetter = function (val) {
           if (isDangerousUrl(String(val))) {
             if (warnDangerousNavigation(String(val), 'location')) {
               _origLocationSetter.call(window, val);
@@ -125,7 +144,8 @@
           } else {
             _origLocationSetter.call(window, val);
           }
-        });
+        };
+        window.__defineSetter__('location', _patchedLocationSetter);
       }
     }
   } catch (e) {
@@ -137,7 +157,7 @@
 
   var _origOpen = window.open;
 
-  window.open = function (url, target, features) {
+  var _patchedOpen = function (url, target, features) {
     // 如果 URL 是危险文件 → 弹窗确认
     if (url && isDangerousUrl(String(url))) {
       if (!warnDangerousNavigation(String(url), 'window.open')) {
@@ -152,11 +172,29 @@
     }
     return null;
   };
+  window.open = _patchedOpen;
 
   // 保留原始 open 的引用（防止其他脚本覆盖后丢失）
   window.open.__virusDetector_original = _origOpen;
 
-  // ==================== 3. 标记已注入 ====================
+  // ==================== 3. 支持认证页动态卸载 ====================
+
+  function disableNavigationGuard() {
+    try {
+      if (window.open === _patchedOpen) window.open = _origOpen;
+      if (_origLocationSetter && _patchedLocationSetter && window.__lookupSetter__ &&
+          window.__lookupSetter__('location') === _patchedLocationSetter) {
+        window.__defineSetter__('location', _origLocationSetter);
+      }
+    } catch (e) { /* 恢复失败时保持静默 */ }
+
+    document.removeEventListener(DISABLE_GUARD_EVENT, disableNavigationGuard);
+    delete window.__virusDetectorNavGuard;
+  }
+
+  document.addEventListener(DISABLE_GUARD_EVENT, disableNavigationGuard);
+
+  // ==================== 4. 标记已注入 ====================
 
   window.__virusDetectorNavGuard = true;
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
   ],
   "background": {
     "service_worker": "background/service-worker.js",
-    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [

--- a/tests/domain-database.test.mjs
+++ b/tests/domain-database.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DomainDatabase } from '../background/domain-database.js';
+
+test('GitLab is registered as an official developer platform', () => {
+  const entry = DomainDatabase.findByDomain('gitlab.com');
+
+  assert.ok(entry);
+  assert.equal(entry.name, 'GitLab');
+  assert.deepEqual(entry.officialDomains, ['gitlab.com']);
+  assert.equal(entry.correctUrl, 'https://gitlab.com');
+  assert.equal(entry.isChineseBrand, false);
+});
+
+test('GitLab subdomains resolve to the official GitLab entry', () => {
+  assert.equal(DomainDatabase.findByDomain('about.gitlab.com')?.name, 'GitLab');
+});
+
+test('GitLab lookalike domains point users to the official website', () => {
+  const spoof = DomainDatabase.detectSpoof('gitlab-login.example.com');
+
+  assert.ok(spoof);
+  assert.equal(spoof.entry.name, 'GitLab');
+  assert.equal(spoof.officialDomain, 'gitlab.com');
+  assert.equal(spoof.correctUrl, 'https://gitlab.com');
+});
+

--- a/tests/extension-safety.test.mjs
+++ b/tests/extension-safety.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+
+const manifest = JSON.parse(readFileSync(new URL('../manifest.json', import.meta.url), 'utf8'));
+const navigationGuard = readFileSync(new URL('../content/navigation-guard.js', import.meta.url), 'utf8');
+const contentScript = readFileSync(new URL('../content/content-script.js', import.meta.url), 'utf8');
+const serviceWorker = readFileSync(new URL('../background/service-worker.js', import.meta.url), 'utf8');
+
+function sourceBetween(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(start, -1, `missing source marker: ${startMarker}`);
+  assert.notEqual(end, -1, `missing source marker: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+function runNavigationGuard(url) {
+  const listeners = new Map();
+  const document = {
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type);
+    },
+    dispatchEvent(event) {
+      listeners.get(event.type)?.(event);
+    }
+  };
+  const originalOpen = function originalOpen() {};
+  const window = { location: new URL(url), open: originalOpen };
+
+  runInNewContext(navigationGuard, {
+    URL,
+    confirm: () => true,
+    document,
+    window
+  });
+
+  return { document, originalOpen, window };
+}
+
+test('the MAIN-world guard exits before patching authentication pages', () => {
+  const mainWorldScripts = manifest.content_scripts
+    .filter((entry) => entry.world === 'MAIN')
+    .flatMap((entry) => entry.js || []);
+  const gate = navigationGuard.indexOf('isSensitiveAuthenticationUrl(window.location.href)');
+  const openPatch = navigationGuard.indexOf('window.open =');
+
+  assert.deepEqual(mainWorldScripts, ['content/navigation-guard.js']);
+  assert.notEqual(gate, -1, 'navigation guard must detect authentication URLs');
+  assert.notEqual(openPatch, -1, 'ordinary pages retain the original navigation guard');
+  assert.ok(gate < openPatch, 'authentication URLs must exit before browser APIs are patched');
+  assert.match(navigationGuard, /console/);
+});
+
+test('Manifest V3 uses only a service worker background entry', () => {
+  assert.equal(manifest.manifest_version, 3);
+  assert.equal(manifest.background.service_worker, 'background/service-worker.js');
+  assert.equal(manifest.background.type, 'module');
+  assert.equal('scripts' in manifest.background, false);
+});
+
+test('navigation guard bypasses auth URLs and can unload for dynamic login', () => {
+  for (const url of [
+    'https://example.com/login',
+    'https://accounts.example.com/home',
+    'https://console.example.com/dashboard',
+    'https://example.com/security/2fa/challenge'
+  ]) {
+    const auth = runNavigationGuard(url);
+    assert.equal(auth.window.open, auth.originalOpen, url);
+  }
+
+  const ordinary = runNavigationGuard('https://example.com/products');
+  assert.notEqual(ordinary.window.open, ordinary.originalOpen);
+  ordinary.document.dispatchEvent({ type: 'virus-detector:disable-navigation-guard' });
+  assert.equal(ordinary.window.open, ordinary.originalOpen);
+});
+
+test('authentication pages keep passive analysis but disable active link probes', () => {
+  const init = sourceBetween(contentScript, 'async function init()', 'if (document.readyState');
+
+  assert.match(init, /isAuthenticationPage\s*\(/);
+  assert.match(init, /checkDeadLinks:\s*_cachedCheckDeadLinks\s*&&\s*!authenticationPage/);
+});
+
+test('ordinary page probes retain their count but cannot carry login credentials', () => {
+  const linkCollector = sourceBetween(
+    contentScript,
+    'async function collectLinkMetrics',
+    '// ==================== 规则五：页面度量采集'
+  );
+
+  assert.match(linkCollector, /uniqueCandidates\.slice\(0,\s*5\)/);
+  assert.match(linkCollector, /method:\s*['"]HEAD['"]/);
+  assert.match(linkCollector, /credentials:\s*['"]omit['"]/);
+  assert.match(linkCollector, /referrerPolicy:\s*['"]no-referrer['"]/);
+});
+
+test('whitelisted pages exit before analysis is scheduled', () => {
+  const init = sourceBetween(contentScript, 'async function init()', 'if (document.readyState');
+  const gate = init.indexOf('shouldSkipPageAnalysis');
+  const firstSchedule = init.indexOf('scheduleAnalysis');
+
+  assert.notEqual(gate, -1, 'init must evaluate the whitelist gate');
+  assert.notEqual(firstSchedule, -1, 'ordinary pages must still schedule analysis');
+  assert.ok(gate < firstSchedule, 'whitelist must be checked before scheduling analysis');
+});
+
+test('authentication pages are excluded before the full blocker is injected', () => {
+  const wrapper = sourceBetween(
+    serviceWorker,
+    'async function injectDownloadBlocker',
+    'function injectBlockerFunc'
+  );
+  const fullBlocker = sourceBetween(
+    serviceWorker,
+    'function injectBlockerFunc',
+    '// ==================== 页面分析 ===================='
+  );
+  const gate = wrapper.indexOf('isSensitiveAuthenticationUrl');
+  const injection = wrapper.indexOf('chrome.scripting.executeScript');
+
+  assert.notEqual(gate, -1, 'download blocker must detect authentication URLs');
+  assert.notEqual(injection, -1, 'ordinary pages retain script injection');
+  assert.ok(gate < injection, 'authentication URLs must exit before script injection');
+  assert.match(wrapper, /_authenticationTabs\.has\(tabId\)/);
+  assert.match(fullBlocker, /HTMLAnchorElement\.prototype\.click\s*=/);
+  assert.match(fullBlocker, /new MutationObserver\s*\(/);
+});
+
+test('dynamic login interaction disables both navigation and download blockers', () => {
+  assert.match(contentScript, /type:\s*['"]AUTH_INTERACTION_DETECTED['"]/);
+  const handler = sourceBetween(
+    serviceWorker,
+    "case 'AUTH_INTERACTION_DETECTED':",
+    'case MSG_TYPES.PAGE_ANALYSIS_RESULT:'
+  );
+
+  assert.match(handler, /_authenticationTabs\.add\(tabId\)/);
+  assert.match(handler, /removeDownloadBlocker\(tabId\)/);
+});
+
+test('adding a site to the whitelist removes an existing page blocker', () => {
+  const handler = sourceBetween(
+    serviceWorker,
+    'case MSG_TYPES.ADD_TO_WHITELIST:',
+    'case MSG_TYPES.REMOVE_FROM_WHITELIST:'
+  );
+
+  assert.match(handler, /removeDownloadBlocker\s*\(/);
+});


### PR DESCRIPTION
Skip invasive hooks and active probes on login, 2FA, console, and whitelisted pages while preserving normal-page detection. Correct the MV3 background manifest and register GitLab as an official developer platform.

在登录、双因素认证、控制台和白名单页面上跳过侵入式钩子和主动探针，同时保留对普通页面的检测。修正 MV3 后台清单，并将 GitLab 注册为官方开发者平台。

---

Closes #176 