### PR TITLE
修复本地回环bug

### DIFF
--- a/background/icp-utils.js
+++ b/background/icp-utils.js
@@ -190,6 +190,7 @@ const ICP_EXEMPT_DOMAINS = new Set([
   // 本地/内网专用（RFC 6761/6762/8375，不暴露公网）
   'local',         // RFC 6762: 局域网 mDNS（打印机/NAS/树莓派）
   'localhost',     // RFC 6761: 本机回环（127.0.0.1）
+  '127.0.0.1',     // 同上
   'home.arpa',     // RFC 8375: 家庭内网
   'internal',      // ICANN 保留: 企业内部网络
   'test',          // RFC 6761: 开发测试


### PR DESCRIPTION
close #190 
---
网段去掉广播地址和网络位，实际上是`127.0.0.1~127.255.255.254`，估计大部分人不知道这些范围都是本地回环，还有ipv6的本地回环`0:0:0:0:0:0:0:1`或者`::1`,估计99%的人遇不到就不加了