### PR TITLE
fix: redact URLs from public reports

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1546,17 +1546,16 @@ async function _applyIcpUpdate(snapshot, icpApi) {
  */
 async function _postReportToWorker(reportType, domain, note) {
   try {
-    // 收集当前标签页的检测详情（用于丰富 Issue body）
+    // Public GitHub Issues must not include page URLs. The Worker renders rule
+    // results from an allowlist of non-sensitive fields before publishing them.
     let score = 0;
     let ruleResults = null;
-    let pageUrl = '';
     try {
       const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
       if (tabs.length > 0) {
         const ts = await loadTabState(tabs[0].id);
         score = ts.score || 0;
         ruleResults = ts.ruleResults || null;
-        pageUrl = ts.url || tabs[0].url || '';
       }
     } catch (e) { /* 获取 tabState 失败，使用默认值 */ }
 
@@ -1567,8 +1566,7 @@ async function _postReportToWorker(reportType, domain, note) {
       version: VERSION,
       timestamp: Date.now(),
       note: note || '',
-      ruleResults,
-      url: pageUrl
+      ruleResults
     };
 
     const response = await fetch(REPORT_API_URL, {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --max-warnings=0 .",
     "check:manifest": "node -e \"JSON.parse(require('node:fs').readFileSync('manifest.json', 'utf8'))\"",
     "check": "npm run check:manifest && npm run lint",
-    "test": "node --test tests/domain-database.test.mjs tests/extension-safety.test.mjs"
+    "test": "node --test tests/domain-database.test.mjs tests/extension-safety.test.mjs tests/report-privacy.test.mjs"
   },
   "devDependencies": {
     "eslint": "^9.31.0",

--- a/tests/report-privacy.test.mjs
+++ b/tests/report-privacy.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { buildBody } from '../worker/report-issue.js';
+
+const serviceWorker = readFileSync(new URL('../background/service-worker.js', import.meta.url), 'utf8');
+
+function sourceBetween(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(start, -1, `missing source marker: ${startMarker}`);
+  assert.notEqual(end, -1, `missing source marker: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+test('public report payload excludes page URLs', () => {
+  const report = sourceBetween(
+    serviceWorker,
+    'async function _postReportToWorker',
+    '// ==================== 事件监听 ===================='
+  );
+
+  assert.doesNotMatch(report, /pageUrl/);
+  assert.doesNotMatch(report, /\burl\s*:/);
+  assert.match(report, /ruleResults/);
+});
+
+test('public issue body retains safe rule details and ignores raw URL details', () => {
+  const sensitiveUrl = 'https://example.com/account/reset?token=private-value#fragment';
+  const body = buildBody({
+    reportType: 'false_positive',
+    domain: 'example.com',
+    score: 5,
+    version: '2.5.1',
+    timestamp: Date.UTC(2026, 6, 23),
+    url: sensitiveUrl,
+    ruleResults: {
+      domainAge: {
+        creationDays: 17,
+        detailCN: `域名年龄: 注册仅17天，来源 ${sensitiveUrl}`,
+        score: 5,
+        triggered: true
+      },
+      rule2: { detail: `downloaded from ${sensitiveUrl}`, score: 20, triggered: true }
+    }
+  });
+
+  assert.match(body, /`example\.com`/);
+  assert.match(body, /域名年龄 \| 已注册 17 天 \| \+5/);
+  assert.match(body, /下载检测 \| 已触发 \| \+20/);
+  assert.doesNotMatch(body, /account\/reset/);
+  assert.doesNotMatch(body, /private-value/);
+  assert.doesNotMatch(body, /downloaded from/);
+});

--- a/worker/report-issue.js
+++ b/worker/report-issue.js
@@ -14,7 +14,7 @@
  * API：
  *   POST /api/report
  *   Content-Type: application/json
- *   Body: { reportType, domain, score, version, timestamp, note, ruleResults, url }
+ *   Body: { reportType, domain, score, version, timestamp, note, ruleResults }
  *   Response: { success: true, issueUrl: "https://github.com/.../issues/123" }
  *
  *   GET /api/version
@@ -38,6 +38,17 @@ const VERSION_CACHE_TTL_MS = 60 * 60 * 1000;
 const LABEL_MAP = {
   'false_positive': ['false-positive', '用户上报'],
   'confirmed_phish': ['confirmed-phish', '用户上报']
+};
+
+const REPORT_RULES = {
+  rule1: '域名仿冒',
+  rule2: '下载检测',
+  rule3: 'ICP备案',
+  rule4: '链接分析',
+  rule5: '代码工程化',
+  domainAge: '域名年龄',
+  ageBonus: '域名减分',
+  downloadLink: '下载链接'
 };
 
 // ---- 环境变量校验 ----
@@ -193,9 +204,9 @@ function buildTitle(reportType, domain) {
 }
 
 // ---- 构建 Issue Body ----
-function buildBody(data) {
+export function buildBody(data) {
   const {
-    reportType, domain, score, version, timestamp, note, ruleResults, url
+    reportType, domain, score, version, timestamp, note, ruleResults
   } = data;
 
   const typeLabel = reportType === 'false_positive' ? '误报' : '确认钓鱼';
@@ -207,28 +218,12 @@ function buildBody(data) {
   body += `| 字段 | 值 |\n|------|----|\n`;
   body += `| 类型 | ${typeLabel} |\n`;
   body += `| 域名 | \`${domain}\` |\n`;
-  if (url) body += `| 页面URL | ${url} |\n`;
   body += `| 风险评分 | ${score ?? '未知'} |\n`;
   body += `| 版本 | ${version ?? '未知'} |\n`;
   body += `| 时间 | ${timeStr} |\n`;
 
-  // 检测详情
-  if (ruleResults) {
-    body += '\n## 检测详情\n\n';
-    body += '| 规则 | 结果 | 得分 |\n|------|------|------|\n';
-    const ruleNames = {
-      rule1: '域名仿冒', rule2: '下载检测', rule3: 'ICP备案',
-      rule4: '链接分析', rule5: '代码工程化',
-      domainAge: '域名年龄', ageBonus: '域名减分', downloadLink: '下载链接'
-    };
-    for (const [key, label] of Object.entries(ruleNames)) {
-      const rule = ruleResults[key];
-      if (!rule) continue;
-      const result = rule.detailCN || rule.detail || '-';
-      const score = rule.score != null ? (rule.score > 0 ? `+${rule.score}` : rule.score) : '-';
-      body += `| ${label} | ${result} | ${score} |\n`;
-    }
-  }
+  const ruleDetails = buildSafeRuleDetails(ruleResults);
+  if (ruleDetails) body += ruleDetails;
 
   // 用户备注
   if (note) {
@@ -239,6 +234,31 @@ function buildBody(data) {
   body += `<sub>🤖 由 Virus Detector 扩展自动上报 | v${version || '?'}</sub>\n`;
 
   return body;
+}
+
+function buildSafeRuleDetails(ruleResults) {
+  if (!ruleResults || typeof ruleResults !== 'object') return '';
+
+  let rows = '';
+  for (const [key, label] of Object.entries(REPORT_RULES)) {
+    const rule = ruleResults[key];
+    if (!rule || typeof rule !== 'object') continue;
+
+    const score = Number.isFinite(rule.score)
+      ? (rule.score > 0 ? `+${rule.score}` : String(rule.score))
+      : '-';
+    let result = rule.status === 'disabled'
+      ? '已关闭'
+      : (rule.triggered === true ? '已触发' : '未触发');
+
+    if (key === 'domainAge' && Number.isSafeInteger(rule.creationDays) && rule.creationDays >= 0) {
+      result = `已注册 ${rule.creationDays} 天`;
+    }
+
+    rows += `| ${label} | ${result} | ${score} |\n`;
+  }
+
+  return rows ? `\n## 检测详情\n\n| 规则 | 结果 | 得分 |\n|------|------|------|\n${rows}` : '';
 }
 
 // ---- 调用 GitHub Issues API ----


### PR DESCRIPTION
## Summary
- stop sending the active page URL with public reports
- preserve safe rule diagnostics while ignoring raw rule details
- add regression coverage for URL redaction

## Verification
- npm run check
- npm test

Fixes #101