### PR TITLE
ci: 引入 CodeQL 安全分析

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
 
 permissions:
   contents: read
@@ -24,3 +30,19 @@ jobs:
         run: npm ci
       - name: Validate manifest and JavaScript
         run: npm run check
+
+  codeql:
+    name: CodeQL analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - name: Analyze code
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## 变更内容

- 在现有 CI 工作流中加入 CodeQL 分析作业
- 使用 `javascript-typescript` 分析 JavaScript/TypeScript 代码
- 为 CodeQL 作业配置最小权限：
  - `contents: read`
  - `security-events: write`
- 在 `push` 和 `pull_request` 触发器中使用 `paths-ignore`
- 跳过仅修改 Markdown 文档或 Issue 模板时的 CI 扫描

## 影响范围

仅修改 GitHub Actions CI 配置，不影响扩展运行时行为。